### PR TITLE
Extract model ID from request body for per-model beta selection

### DIFF
--- a/claude-auth-transform/src/lib.rs
+++ b/claude-auth-transform/src/lib.rs
@@ -41,7 +41,14 @@ where
 {
     let (mut parts, body) = request.into_parts();
 
-    build_request_headers(&mut parts.headers, access_token, "claude-opus-4-6");
+    let model_id = serde_json::from_slice::<serde_json::Value>(body.as_ref())
+        .ok()
+        .and_then(|v| v.get("model")?.as_str().map(String::from));
+    build_request_headers(
+        &mut parts.headers,
+        access_token,
+        model_id.as_deref().unwrap_or(""),
+    );
 
     let body = transform_body(body.as_ref())?;
 


### PR DESCRIPTION
## Summary

- Parse the actual model ID from the request body JSON before calling `build_request_headers`, replacing the hardcoded `"claude-opus-4-6"` string
- Falls back to empty string (base betas, no model-specific overrides) when model is absent or body is unparseable

## Problem

`build_request_headers` received a hardcoded model ID, so all requests got opus-4-6 beta treatment regardless of the actual model. Haiku requests incorrectly received `interleaved-thinking` (which haiku excludes), and non-4-6 models incorrectly received the `effort-2025-11-24` beta.

Fixes #15