### PR TITLE
Add configurable timeout settings for HTTP client

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{env, sync::{Arc, LazyLock}, time::Duration};
 
 use axum::{
     Router,
@@ -12,6 +12,20 @@ use http_body_util::BodyExt;
 use reqwest::Client;
 use tracing::debug;
 
+static CONNECT_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
+    env::var("PROXY_CONNECT_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map_or(Duration::from_secs(10), Duration::from_secs)
+});
+
+static READ_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
+    env::var("PROXY_READ_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map_or(Duration::from_secs(600), Duration::from_secs)
+});
+
 #[derive(Debug)]
 struct ServerState {
     auth: ClaudeCodeAuthProvider,
@@ -22,9 +36,19 @@ struct ServerState {
 async fn main() {
     tracing_subscriber::fmt::init();
 
+    tracing::info!(
+        connect_timeout = ?*CONNECT_TIMEOUT,
+        read_timeout = ?*READ_TIMEOUT,
+        "Proxy timeout configuration"
+    );
+
     let state = Arc::new(ServerState {
         auth: ClaudeCodeAuthProvider::new(),
-        client: Client::new(),
+        client: Client::builder()
+            .connect_timeout(*CONNECT_TIMEOUT)
+            .read_timeout(*READ_TIMEOUT)
+            .build()
+            .expect("failed to build HTTP client"),
     });
 
     let app = Router::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,8 @@
-use std::{env, sync::{Arc, LazyLock}, time::Duration};
+use std::{
+    env,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
 use axum::{
     Router,


### PR DESCRIPTION
## Summary
This PR adds configurable timeout settings for the HTTP client used by the proxy service. Timeouts can now be customized via environment variables with sensible defaults.

## Key Changes
- Added two new `LazyLock` static variables to manage timeout configuration:
  - `CONNECT_TIMEOUT`: Controls connection timeout (default: 10 seconds)
  - `READ_TIMEOUT`: Controls read timeout (default: 600 seconds)
- Both timeouts are configurable via environment variables:
  - `PROXY_CONNECT_TIMEOUT_SECS`
  - `PROXY_READ_TIMEOUT_SECS`
- Updated the HTTP client builder to apply these timeout settings
- Added informational logging to display the configured timeout values on startup

## Implementation Details
- Used `LazyLock` for lazy initialization of timeout values, ensuring environment variables are only read once
- Implemented fallback defaults using `map_or()` to handle missing or invalid environment variable values
- The timeout configuration is logged at startup for visibility and debugging purposes

https://claude.ai/code/session_01QbX41RrXPTUDXQYJ8fx2R5