### PR TITLE
Add retry logic with configurable backoff for upstream requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2024"
 
 [dependencies]
 axum = "0.8.8"
+bytes = "1"
 claude-auth-providers = { version = "0.1.0", path = "claude-auth-providers" }
 claude-auth-transform = { version = "0.1.0", path = "claude-auth-transform" }
 http = "1.4.0"

--- a/claude-auth-transform/src/response.rs
+++ b/claude-auth-transform/src/response.rs
@@ -22,7 +22,7 @@ where
     })
 }
 
-/// Strips `"name": "mcp_<tool>"` → `"name": "<tool>"` from a byte slice.
+/// Strips `"name": "mcp_<tool>"` -> `"name": "<tool>"` from a byte slice.
 fn strip_tool_prefix(input: &[u8]) -> Bytes {
     let text = String::from_utf8_lossy(input);
     let result = TOOL_PREFIX_RE.replace_all(&text, r#""name": "$1""#);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,22 +1,48 @@
-use std::net::IpAddr;
+use std::{env, net::IpAddr, time::Duration};
 
+/// Runtime configuration for the proxy server, populated from environment
+/// variables on startup.
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
+    /// Host to bind the HTTP listener on.
     pub host: IpAddr,
+    /// Port to bind the HTTP listener on.
     pub port: u16,
+    /// Connect timeout for upstream requests.
+    pub connect_timeout: Duration,
+    /// Read timeout for upstream requests.
+    pub read_timeout: Duration,
+    /// Maximum number of attempts for 429/529 responses (including the
+    /// initial attempt). A value of `3` means 1 initial attempt + 2 retries.
+    pub max_retries: u32,
+    /// When `true`, 5xx server errors (other than 529) are also retried.
+    pub retry_on_5xx: bool,
+    /// Maximum number of attempts for 5xx responses when `retry_on_5xx` is
+    /// enabled. Typically shorter than `max_retries`.
+    pub max_5xx_retries: u32,
 }
 
 impl ServerConfig {
+    /// Build a `ServerConfig` from environment variables, falling back to
+    /// sensible defaults when variables are unset or unparseable.
     pub fn from_env() -> Result<Self, ConfigError> {
-        let host = std::env::var("CLAUDE_PROXY_HOST").unwrap_or_else(|_| "0.0.0.0".to_owned());
-        let port = std::env::var("CLAUDE_PROXY_PORT").unwrap_or_else(|_| "3000".to_owned());
+        let host = env::var("CLAUDE_PROXY_HOST").unwrap_or_else(|_| "0.0.0.0".to_owned());
+        let port = env::var("CLAUDE_PROXY_PORT").unwrap_or_else(|_| "3000".to_owned());
         let host = host
             .parse()
             .map_err(|_| ConfigError::InvalidHost(host.clone()))?;
         let port = port
             .parse()
             .map_err(|_| ConfigError::InvalidPort(port.clone()))?;
-        Ok(Self { host, port })
+        Ok(Self {
+            host,
+            port,
+            connect_timeout: parse_duration_secs("PROXY_CONNECT_TIMEOUT_SECS", 10),
+            read_timeout: parse_duration_secs("PROXY_READ_TIMEOUT_SECS", 600),
+            max_retries: parse_u32("PROXY_MAX_RETRIES", 3),
+            retry_on_5xx: parse_bool("PROXY_RETRY_ON_5XX", false),
+            max_5xx_retries: parse_u32("PROXY_5XX_MAX_RETRIES", 1),
+        })
     }
 }
 
@@ -26,4 +52,25 @@ pub enum ConfigError {
     InvalidHost(String),
     #[error("Invalid port: {0}")]
     InvalidPort(String),
+}
+
+fn parse_duration_secs(var: &str, default_secs: u64) -> Duration {
+    let secs = env::var(var)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(default_secs);
+    Duration::from_secs(secs)
+}
+
+fn parse_u32(var: &str, default: u32) -> u32 {
+    env::var(var)
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(default)
+}
+
+fn parse_bool(var: &str, default: bool) -> bool {
+    env::var(var).ok().map_or(default, |v| {
+        matches!(v.as_str(), "1" | "true" | "TRUE" | "True" | "yes" | "YES")
+    })
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,7 +70,7 @@ fn parse_u32(var: &str, default: u32) -> u32 {
 }
 
 fn parse_bool(var: &str, default: bool) -> bool {
-    env::var(var).ok().map_or(default, |v| match v.as_str() {
+    env::var(var).ok().map_or(default, |v| match v.trim() {
         "1" | "true" | "TRUE" | "True" | "yes" | "YES" => true,
         "0" | "false" | "FALSE" | "False" | "no" | "NO" => false,
         _ => default,

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,19 +49,38 @@ fn parse_duration_secs(var: &str, default_secs: u64) -> Duration {
 }
 
 /// Read the environment variable `var`, parse it as `T`, and return the
-/// parsed value. If the variable is unset or cannot be parsed, return
-/// `default`.
+/// parsed value. If the variable is unset, return `default` silently. If it
+/// is set but cannot be parsed, log a warning and return `default` so a
+/// typo in a critical binding like `CLAUDE_PROXY_HOST` is visible in the
+/// startup logs rather than silently falling back.
 fn parse_or_default<T: FromStr>(var: &str, default: T) -> T {
-    env::var(var)
-        .ok()
-        .and_then(|v| v.parse::<T>().ok())
-        .unwrap_or(default)
+    let Ok(raw) = env::var(var) else {
+        return default;
+    };
+    raw.parse::<T>().unwrap_or_else(|_| {
+        tracing::warn!(
+            var,
+            value = %raw,
+            "Environment variable set but could not be parsed, falling back to default"
+        );
+        default
+    })
 }
 
 fn parse_bool(var: &str, default: bool) -> bool {
-    env::var(var).ok().map_or(default, |v| match v.trim() {
+    let Ok(raw) = env::var(var) else {
+        return default;
+    };
+    match raw.trim() {
         "1" | "true" | "TRUE" | "True" | "yes" | "YES" => true,
         "0" | "false" | "FALSE" | "False" | "no" | "NO" => false,
-        _ => default,
-    })
+        _ => {
+            tracing::warn!(
+                var,
+                value = %raw,
+                "Environment variable set but could not be parsed as a boolean, falling back to default"
+            );
+            default
+        }
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,9 @@
-use std::{env, net::IpAddr, time::Duration};
+use std::{
+    env,
+    net::{IpAddr, Ipv4Addr},
+    str::FromStr,
+    time::Duration,
+};
 
 /// Runtime configuration for the proxy server, populated from environment
 /// variables on startup.
@@ -25,47 +30,31 @@ pub struct ServerConfig {
 impl ServerConfig {
     /// Build a `ServerConfig` from environment variables, falling back to
     /// sensible defaults when variables are unset or unparseable.
-    pub fn from_env() -> Result<Self, ConfigError> {
-        let host = env::var("CLAUDE_PROXY_HOST").unwrap_or_else(|_| "0.0.0.0".to_owned());
-        let port = env::var("CLAUDE_PROXY_PORT").unwrap_or_else(|_| "3000".to_owned());
-        let host = host
-            .parse()
-            .map_err(|_| ConfigError::InvalidHost(host.clone()))?;
-        let port = port
-            .parse()
-            .map_err(|_| ConfigError::InvalidPort(port.clone()))?;
-        Ok(Self {
-            host,
-            port,
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self {
+            host: parse_or_default("CLAUDE_PROXY_HOST", IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
+            port: parse_or_default("CLAUDE_PROXY_PORT", 3000),
             connect_timeout: parse_duration_secs("PROXY_CONNECT_TIMEOUT_SECS", 10),
             read_timeout: parse_duration_secs("PROXY_READ_TIMEOUT_SECS", 600),
-            max_retries: parse_u32("PROXY_MAX_RETRIES", 3),
+            max_retries: parse_or_default("PROXY_MAX_RETRIES", 3),
             retry_on_5xx: parse_bool("PROXY_RETRY_ON_5XX", false),
-            max_5xx_retries: parse_u32("PROXY_5XX_MAX_RETRIES", 1),
-        })
+            max_5xx_retries: parse_or_default("PROXY_5XX_MAX_RETRIES", 1),
+        }
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum ConfigError {
-    #[error("Invalid host: {0}")]
-    InvalidHost(String),
-    #[error("Invalid port: {0}")]
-    InvalidPort(String),
-}
-
 fn parse_duration_secs(var: &str, default_secs: u64) -> Duration {
-    let secs = env::var(var)
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(default_secs);
-    Duration::from_secs(secs)
+    Duration::from_secs(parse_or_default(var, default_secs))
 }
 
-fn parse_u32(var: &str, default: u32) -> u32 {
+/// Read the environment variable `var`, parse it as `T`, and return the
+/// parsed value. If the variable is unset or cannot be parsed, return
+/// `default`.
+fn parse_or_default<T: FromStr>(var: &str, default: T) -> T {
     env::var(var)
         .ok()
-        .and_then(|v| v.parse::<u32>().ok())
+        .and_then(|v| v.parse::<T>().ok())
         .unwrap_or(default)
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,7 +70,9 @@ fn parse_u32(var: &str, default: u32) -> u32 {
 }
 
 fn parse_bool(var: &str, default: bool) -> bool {
-    env::var(var).ok().map_or(default, |v| {
-        matches!(v.as_str(), "1" | "true" | "TRUE" | "True" | "yes" | "YES")
+    env::var(var).ok().map_or(default, |v| match v.as_str() {
+        "1" | "true" | "TRUE" | "True" | "yes" | "YES" => true,
+        "0" | "false" | "FALSE" | "False" | "no" | "NO" => false,
+        _ => default,
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ struct ServerState {
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let config = ServerConfig::from_env().unwrap();
+    let config = ServerConfig::from_env();
 
     tracing::info!(
         host = %config.host,
@@ -148,7 +148,7 @@ async fn messages_handler(State(state): State<Arc<ServerState>>, req: Request) -
     let body = Bytes::from(body);
     let res = execute_with_retry(&state, parts, body).await;
 
-    // Convert reqwest::Response → http::Response with a streaming body
+    // Convert reqwest::Response -> http::Response with a streaming body
     let status = res.status();
     let headers = res.headers().clone();
     let stream = res.bytes_stream();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,6 @@
 mod config;
 
-use std::{
-    env,
-    sync::{Arc, LazyLock},
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use axum::{
     Json, Router,
@@ -22,45 +18,44 @@ use tracing::{debug, info};
 
 use crate::config::ServerConfig;
 
-static CONNECT_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
-    env::var("PROXY_CONNECT_TIMEOUT_SECS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .map_or(Duration::from_secs(10), Duration::from_secs)
-});
-
-static READ_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
-    env::var("PROXY_READ_TIMEOUT_SECS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .map_or(Duration::from_secs(600), Duration::from_secs)
-});
+/// Upper bound on honoring a `Retry-After` response header. Protects against a
+/// misbehaving upstream asking the proxy to stall for hours.
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(60);
 
 #[derive(Debug)]
 struct ServerState {
     auth: ClaudeCodeAuthProvider,
     client: Client,
+    config: ServerConfig,
 }
 
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let cfg = ServerConfig::from_env().unwrap();
+    let config = ServerConfig::from_env().unwrap();
 
     tracing::info!(
-        connect_timeout = ?*CONNECT_TIMEOUT,
-        read_timeout = ?*READ_TIMEOUT,
-        "Proxy timeout configuration"
+        host = %config.host,
+        port = config.port,
+        connect_timeout = ?config.connect_timeout,
+        read_timeout = ?config.read_timeout,
+        max_retries = config.max_retries,
+        retry_on_5xx = config.retry_on_5xx,
+        max_5xx_retries = config.max_5xx_retries,
+        "Proxy configuration"
     );
 
+    let host = config.host;
+    let port = config.port;
     let state = Arc::new(ServerState {
         auth: ClaudeCodeAuthProvider::new(),
         client: Client::builder()
-            .connect_timeout(*CONNECT_TIMEOUT)
-            .read_timeout(*READ_TIMEOUT)
+            .connect_timeout(config.connect_timeout)
+            .read_timeout(config.read_timeout)
             .build()
             .expect("failed to build HTTP client"),
+        config,
     });
 
     let app = Router::new()
@@ -68,10 +63,8 @@ async fn main() {
         .route("/ready", axum::routing::get(ready_handler))
         .route("/v1/{*rest}", axum::routing::any(messages_handler))
         .with_state(state);
-    let listener = tokio::net::TcpListener::bind((cfg.host, cfg.port))
-        .await
-        .unwrap();
-    info!("Listening on port 3000");
+    let listener = tokio::net::TcpListener::bind((host, port)).await.unwrap();
+    info!("Listening on {host}:{port}");
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
         .await
@@ -146,10 +139,10 @@ async fn messages_handler(State(state): State<Arc<ServerState>>, req: Request) -
 
     let req = transform_request(req, &token).unwrap();
 
-    debug!("Forwarding request: {} {}", req.method(), req.uri());
-    let req = reqwest::Request::try_from(req).unwrap();
+    let (parts, body) = req.into_parts();
+    debug!("Forwarding request: {} {}", parts.method, parts.uri);
 
-    let res = state.client.execute(req).await.unwrap();
+    let res = execute_with_retry(&state, parts, body).await;
 
     // Convert reqwest::Response → http::Response with a streaming body
     let status = res.status();
@@ -163,4 +156,260 @@ async fn messages_handler(State(state): State<Arc<ServerState>>, req: Request) -
 
     // Wrap through ClaudeBody to strip tool prefixes from SSE events
     transform_response(response).map(Body::new)
+}
+
+/// Execute the upstream request with retries for transient failures.
+///
+/// Retries on:
+/// - 429 (rate limited) and 529 (overloaded): up to `config.max_retries` attempts
+/// - Other 5xx: up to `config.max_5xx_retries` attempts, if `config.retry_on_5xx`
+/// - Network timeouts / connect errors: up to `config.max_retries` attempts
+///
+/// Panics on non-retryable network errors or when retries are exhausted on an
+/// error, matching the existing `.unwrap()` behavior at this call site.
+async fn execute_with_retry(
+    state: &ServerState,
+    parts: http::request::Parts,
+    body: Vec<u8>,
+) -> reqwest::Response {
+    let mut attempt: u32 = 0;
+    loop {
+        let http_req = http::Request::from_parts(parts.clone(), body.clone());
+        let reqwest_req = reqwest::Request::try_from(http_req).unwrap();
+
+        match state.client.execute(reqwest_req).await {
+            Ok(res) => {
+                if let Some(delay) = retry_delay(
+                    res.status(),
+                    attempt,
+                    res.headers(),
+                    state.config.max_retries,
+                    state.config.retry_on_5xx,
+                    state.config.max_5xx_retries,
+                ) {
+                    debug!(
+                        status = res.status().as_u16(),
+                        attempt,
+                        delay_secs = delay.as_secs(),
+                        "Retryable upstream status, retrying after delay"
+                    );
+                    // Drain the response body so reqwest can return the
+                    // connection to its pool before we sleep.
+                    let _ = res.bytes().await;
+                    tokio::time::sleep(delay).await;
+                    attempt += 1;
+                    continue;
+                }
+                return res;
+            }
+            Err(e) if (e.is_timeout() || e.is_connect()) && attempt < state.config.max_retries => {
+                let delay = Duration::from_secs(u64::from(attempt + 1) * 2);
+                debug!(
+                    error = %e,
+                    attempt,
+                    delay_secs = delay.as_secs(),
+                    "Transient network error, retrying after delay"
+                );
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+            Err(e) => panic!("upstream request failed: {e}"),
+        }
+    }
+}
+
+/// Compute the retry delay for a response, or `None` if the response should be
+/// returned to the caller as-is.
+///
+/// - 429 and 529 are retried up to `max_retries` attempts.
+/// - Other 5xx are retried up to `max_5xx_retries` attempts when `retry_on_5xx`
+///   is enabled.
+/// - When the `Retry-After` header is present (integer seconds), it is
+///   honored, capped at [`MAX_RETRY_AFTER`].
+/// - Otherwise falls back to `(attempt + 1) * 2` seconds of linear backoff.
+fn retry_delay(
+    status: StatusCode,
+    attempt: u32,
+    headers: &reqwest::header::HeaderMap,
+    max_retries: u32,
+    retry_on_5xx: bool,
+    max_5xx_retries: u32,
+) -> Option<Duration> {
+    let code = status.as_u16();
+    let is_rate_limited = code == 429 || code == 529;
+    let is_other_5xx = !is_rate_limited && status.is_server_error();
+
+    let budget = if is_rate_limited {
+        max_retries
+    } else if is_other_5xx && retry_on_5xx {
+        max_5xx_retries
+    } else {
+        return None;
+    };
+
+    // `attempt` is 0-indexed; allow `attempt < budget - 1` retries after the
+    // initial call, i.e. a budget of 3 means up to 3 total attempts.
+    if attempt + 1 >= budget {
+        return None;
+    }
+
+    let header_delay = headers
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .map(|d| d.min(MAX_RETRY_AFTER));
+
+    Some(header_delay.unwrap_or_else(|| Duration::from_secs(u64::from(attempt + 1) * 2)))
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
+
+    use super::*;
+
+    fn empty_headers() -> HeaderMap {
+        HeaderMap::new()
+    }
+
+    fn headers_with_retry_after(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(RETRY_AFTER, HeaderValue::from_str(value).unwrap());
+        h
+    }
+
+    #[test]
+    fn retry_delay_429_first_attempt_uses_backoff() {
+        let delay = retry_delay(
+            StatusCode::TOO_MANY_REQUESTS,
+            0,
+            &empty_headers(),
+            3,
+            false,
+            1,
+        );
+        assert_eq!(delay, Some(Duration::from_secs(2)));
+    }
+
+    #[test]
+    fn retry_delay_529_first_attempt_uses_backoff() {
+        let status = StatusCode::from_u16(529).unwrap();
+        let delay = retry_delay(status, 0, &empty_headers(), 3, false, 1);
+        assert_eq!(delay, Some(Duration::from_secs(2)));
+    }
+
+    #[test]
+    fn retry_delay_respects_retry_after_header() {
+        let headers = headers_with_retry_after("5");
+        let delay = retry_delay(StatusCode::TOO_MANY_REQUESTS, 0, &headers, 3, false, 1);
+        assert_eq!(delay, Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn retry_delay_caps_retry_after_at_max() {
+        let headers = headers_with_retry_after("9999");
+        let delay = retry_delay(StatusCode::TOO_MANY_REQUESTS, 0, &headers, 3, false, 1);
+        assert_eq!(delay, Some(MAX_RETRY_AFTER));
+    }
+
+    #[test]
+    fn retry_delay_ignores_unparseable_retry_after() {
+        let headers = headers_with_retry_after("Wed, 21 Oct 2015 07:28:00 GMT");
+        let delay = retry_delay(StatusCode::TOO_MANY_REQUESTS, 0, &headers, 3, false, 1);
+        // Falls back to exponential backoff
+        assert_eq!(delay, Some(Duration::from_secs(2)));
+    }
+
+    #[test]
+    fn retry_delay_exponential_backoff_progression() {
+        let headers = empty_headers();
+        assert_eq!(
+            retry_delay(StatusCode::TOO_MANY_REQUESTS, 0, &headers, 5, false, 1),
+            Some(Duration::from_secs(2))
+        );
+        assert_eq!(
+            retry_delay(StatusCode::TOO_MANY_REQUESTS, 1, &headers, 5, false, 1),
+            Some(Duration::from_secs(4))
+        );
+        assert_eq!(
+            retry_delay(StatusCode::TOO_MANY_REQUESTS, 2, &headers, 5, false, 1),
+            Some(Duration::from_secs(6))
+        );
+    }
+
+    #[test]
+    fn retry_delay_exhausted_returns_none() {
+        // budget = 3 means 3 total attempts (attempts 0, 1, 2). After attempt 2,
+        // we should not retry again.
+        let delay = retry_delay(
+            StatusCode::TOO_MANY_REQUESTS,
+            2,
+            &empty_headers(),
+            3,
+            false,
+            1,
+        );
+        assert_eq!(delay, None);
+    }
+
+    #[test]
+    fn retry_delay_200_returns_none() {
+        let delay = retry_delay(StatusCode::OK, 0, &empty_headers(), 3, true, 3);
+        assert_eq!(delay, None);
+    }
+
+    #[test]
+    fn retry_delay_400_returns_none() {
+        let delay = retry_delay(StatusCode::BAD_REQUEST, 0, &empty_headers(), 3, true, 3);
+        assert_eq!(delay, None);
+    }
+
+    #[test]
+    fn retry_delay_500_not_retried_when_disabled() {
+        let delay = retry_delay(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            0,
+            &empty_headers(),
+            3,
+            false,
+            1,
+        );
+        assert_eq!(delay, None);
+    }
+
+    #[test]
+    fn retry_delay_500_retried_when_enabled() {
+        let delay = retry_delay(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            0,
+            &empty_headers(),
+            3,
+            true,
+            2,
+        );
+        assert_eq!(delay, Some(Duration::from_secs(2)));
+    }
+
+    #[test]
+    fn retry_delay_500_exhausts_5xx_budget() {
+        // 5xx budget = 2 means 2 total attempts. After attempt 1, no more retries.
+        let delay = retry_delay(StatusCode::BAD_GATEWAY, 1, &empty_headers(), 3, true, 2);
+        assert_eq!(delay, None);
+    }
+
+    #[test]
+    fn retry_delay_zero_budget_returns_none() {
+        // A budget of 0 means no attempts at all - but the initial call already
+        // happened, so we should just not retry.
+        let delay = retry_delay(
+            StatusCode::TOO_MANY_REQUESTS,
+            0,
+            &empty_headers(),
+            0,
+            false,
+            0,
+        );
+        assert_eq!(delay, None);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,7 @@ async fn execute_with_retry(
         let reqwest_req = reqwest::Request::try_from(http_req).unwrap();
 
         match state.client.execute(reqwest_req).await {
-            Ok(res) => {
+            Ok(mut res) => {
                 if let Some(delay) = retry_delay(
                     res.status(),
                     attempt,
@@ -193,16 +193,19 @@ async fn execute_with_retry(
                         delay_secs = delay.as_secs(),
                         "Retryable upstream status, retrying after delay"
                     );
-                    // Drain the response body so reqwest can return the
-                    // connection to its pool before we sleep.
-                    let _ = res.bytes().await;
+                    // Drain the response body in a streaming fashion so the
+                    // connection can be returned to the pool without
+                    // buffering a potentially large error body in memory.
+                    while let Ok(Some(_)) = res.chunk().await {}
                     tokio::time::sleep(delay).await;
                     attempt += 1;
                     continue;
                 }
                 return res;
             }
-            Err(e) if (e.is_timeout() || e.is_connect()) && attempt < state.config.max_retries => {
+            Err(e)
+                if (e.is_timeout() || e.is_connect()) && attempt + 1 < state.config.max_retries =>
+            {
                 let delay = Duration::from_secs(u64::from(attempt + 1) * 2);
                 debug!(
                     error = %e,
@@ -317,12 +320,12 @@ mod tests {
     fn retry_delay_ignores_unparseable_retry_after() {
         let headers = headers_with_retry_after("Wed, 21 Oct 2015 07:28:00 GMT");
         let delay = retry_delay(StatusCode::TOO_MANY_REQUESTS, 0, &headers, 3, false, 1);
-        // Falls back to exponential backoff
+        // Falls back to linear backoff
         assert_eq!(delay, Some(Duration::from_secs(2)));
     }
 
     #[test]
-    fn retry_delay_exponential_backoff_progression() {
+    fn retry_delay_linear_backoff_progression() {
         let headers = empty_headers();
         assert_eq!(
             retry_delay(StatusCode::TOO_MANY_REQUESTS, 0, &headers, 5, false, 1),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+use bytes::Bytes;
 use claude_auth_providers::{ClaudeAuthProvider, claude_code::ClaudeCodeAuthProvider};
 use claude_auth_transform::{transform_request, transform_response};
 use http_body_util::BodyExt;
@@ -142,6 +143,9 @@ async fn messages_handler(State(state): State<Arc<ServerState>>, req: Request) -
     let (parts, body) = req.into_parts();
     debug!("Forwarding request: {} {}", parts.method, parts.uri);
 
+    // Convert the body to `Bytes` so that cloning for retries is cheap
+    // (reference-counted) instead of deep-copying the Vec on each attempt.
+    let body = Bytes::from(body);
     let res = execute_with_retry(&state, parts, body).await;
 
     // Convert reqwest::Response → http::Response with a streaming body
@@ -160,102 +164,95 @@ async fn messages_handler(State(state): State<Arc<ServerState>>, req: Request) -
 
 /// Execute the upstream request with retries for transient failures.
 ///
-/// Retries on:
+/// Each retry category has an independent budget so that, for example, a
+/// single connect failure does not eat into the budget available for 429s:
 /// - 429 (rate limited) and 529 (overloaded): up to `config.max_retries` attempts
 /// - Other 5xx: up to `config.max_5xx_retries` attempts, if `config.retry_on_5xx`
 /// - Network timeouts / connect errors: up to `config.max_retries` attempts
 ///
-/// Panics on non-retryable network errors or when retries are exhausted on an
-/// error, matching the existing `.unwrap()` behavior at this call site.
+/// On HTTP status exhaustion the final response is returned to the caller so
+/// the upstream error is propagated downstream. This function only panics on
+/// non-retryable network errors or when the network retry budget is exhausted,
+/// matching the existing `.unwrap()` behavior at this call site.
 async fn execute_with_retry(
     state: &ServerState,
     parts: http::request::Parts,
-    body: Vec<u8>,
+    body: Bytes,
 ) -> reqwest::Response {
-    let mut attempt: u32 = 0;
+    // Each retry category has an independent budget: a failure in one
+    // category must not consume retries reserved for another.
+    let mut rate_limit_attempts: u32 = 0;
+    let mut other_5xx_attempts: u32 = 0;
+    let mut network_attempts: u32 = 0;
+
     loop {
+        // Cloning `Bytes` is a cheap Arc bump, not a deep copy of the body.
         let http_req = http::Request::from_parts(parts.clone(), body.clone());
         let reqwest_req = reqwest::Request::try_from(http_req).unwrap();
 
         match state.client.execute(reqwest_req).await {
             Ok(mut res) => {
-                if let Some(delay) = retry_delay(
-                    res.status(),
-                    attempt,
-                    res.headers(),
-                    state.config.max_retries,
-                    state.config.retry_on_5xx,
-                    state.config.max_5xx_retries,
-                ) {
-                    debug!(
-                        status = res.status().as_u16(),
-                        attempt,
-                        delay_secs = delay.as_secs(),
-                        "Retryable upstream status, retrying after delay"
-                    );
-                    // Drain the response body in a streaming fashion so the
-                    // connection can be returned to the pool without
-                    // buffering a potentially large error body in memory.
-                    while let Ok(Some(_)) = res.chunk().await {}
-                    tokio::time::sleep(delay).await;
-                    attempt += 1;
-                    continue;
+                let status = res.status();
+                let code = status.as_u16();
+                let is_rate_limited = code == 429 || code == 529;
+                let is_other_5xx = !is_rate_limited && status.is_server_error();
+
+                // Determine which counter/budget applies, or return the
+                // response as-is for non-retryable statuses.
+                let (attempt, budget) = if is_rate_limited {
+                    (&mut rate_limit_attempts, state.config.max_retries)
+                } else if is_other_5xx && state.config.retry_on_5xx {
+                    (&mut other_5xx_attempts, state.config.max_5xx_retries)
+                } else {
+                    return res;
+                };
+
+                // `*attempt` is 0-indexed and counts the attempt just made.
+                // A budget of N means up to N total attempts, so once the
+                // initial call + prior retries reach the budget we stop.
+                if *attempt + 1 >= budget {
+                    return res;
                 }
-                return res;
+
+                let delay = retry_delay(*attempt, res.headers());
+                debug!(
+                    status = code,
+                    attempt = *attempt,
+                    delay_secs = delay.as_secs(),
+                    "Retryable upstream status, retrying after delay"
+                );
+                // Drain the response body in a streaming fashion so the
+                // connection can be returned to the pool without buffering a
+                // potentially large error body in memory.
+                while let Ok(Some(_)) = res.chunk().await {}
+                tokio::time::sleep(delay).await;
+                *attempt += 1;
             }
             Err(e)
-                if (e.is_timeout() || e.is_connect()) && attempt + 1 < state.config.max_retries =>
+                if (e.is_timeout() || e.is_connect())
+                    && network_attempts + 1 < state.config.max_retries =>
             {
-                let delay = Duration::from_secs(u64::from(attempt + 1) * 2);
+                let delay = Duration::from_secs(u64::from(network_attempts + 1) * 2);
                 debug!(
                     error = %e,
-                    attempt,
+                    attempt = network_attempts,
                     delay_secs = delay.as_secs(),
                     "Transient network error, retrying after delay"
                 );
                 tokio::time::sleep(delay).await;
-                attempt += 1;
+                network_attempts += 1;
             }
             Err(e) => panic!("upstream request failed: {e}"),
         }
     }
 }
 
-/// Compute the retry delay for a response, or `None` if the response should be
-/// returned to the caller as-is.
+/// Compute how long to wait before the next retry attempt.
 ///
-/// - 429 and 529 are retried up to `max_retries` attempts.
-/// - Other 5xx are retried up to `max_5xx_retries` attempts when `retry_on_5xx`
-///   is enabled.
 /// - When the `Retry-After` header is present (integer seconds), it is
 ///   honored, capped at [`MAX_RETRY_AFTER`].
 /// - Otherwise falls back to `(attempt + 1) * 2` seconds of linear backoff.
-fn retry_delay(
-    status: StatusCode,
-    attempt: u32,
-    headers: &reqwest::header::HeaderMap,
-    max_retries: u32,
-    retry_on_5xx: bool,
-    max_5xx_retries: u32,
-) -> Option<Duration> {
-    let code = status.as_u16();
-    let is_rate_limited = code == 429 || code == 529;
-    let is_other_5xx = !is_rate_limited && status.is_server_error();
-
-    let budget = if is_rate_limited {
-        max_retries
-    } else if is_other_5xx && retry_on_5xx {
-        max_5xx_retries
-    } else {
-        return None;
-    };
-
-    // `attempt` is 0-indexed; allow `attempt < budget - 1` retries after the
-    // initial call, i.e. a budget of 3 means up to 3 total attempts.
-    if attempt + 1 >= budget {
-        return None;
-    }
-
+fn retry_delay(attempt: u32, headers: &reqwest::header::HeaderMap) -> Duration {
     let header_delay = headers
         .get(reqwest::header::RETRY_AFTER)
         .and_then(|v| v.to_str().ok())
@@ -263,7 +260,7 @@ fn retry_delay(
         .map(Duration::from_secs)
         .map(|d| d.min(MAX_RETRY_AFTER));
 
-    Some(header_delay.unwrap_or_else(|| Duration::from_secs(u64::from(attempt + 1) * 2)))
+    header_delay.unwrap_or_else(|| Duration::from_secs(u64::from(attempt + 1) * 2))
 }
 
 #[cfg(test)]
@@ -283,136 +280,45 @@ mod tests {
     }
 
     #[test]
-    fn retry_delay_429_first_attempt_uses_backoff() {
-        let delay = retry_delay(
-            StatusCode::TOO_MANY_REQUESTS,
-            0,
-            &empty_headers(),
-            3,
-            false,
-            1,
-        );
-        assert_eq!(delay, Some(Duration::from_secs(2)));
-    }
-
-    #[test]
-    fn retry_delay_529_first_attempt_uses_backoff() {
-        let status = StatusCode::from_u16(529).unwrap();
-        let delay = retry_delay(status, 0, &empty_headers(), 3, false, 1);
-        assert_eq!(delay, Some(Duration::from_secs(2)));
+    fn retry_delay_first_attempt_uses_backoff() {
+        let delay = retry_delay(0, &empty_headers());
+        assert_eq!(delay, Duration::from_secs(2));
     }
 
     #[test]
     fn retry_delay_respects_retry_after_header() {
         let headers = headers_with_retry_after("5");
-        let delay = retry_delay(StatusCode::TOO_MANY_REQUESTS, 0, &headers, 3, false, 1);
-        assert_eq!(delay, Some(Duration::from_secs(5)));
+        let delay = retry_delay(0, &headers);
+        assert_eq!(delay, Duration::from_secs(5));
     }
 
     #[test]
     fn retry_delay_caps_retry_after_at_max() {
         let headers = headers_with_retry_after("9999");
-        let delay = retry_delay(StatusCode::TOO_MANY_REQUESTS, 0, &headers, 3, false, 1);
-        assert_eq!(delay, Some(MAX_RETRY_AFTER));
+        let delay = retry_delay(0, &headers);
+        assert_eq!(delay, MAX_RETRY_AFTER);
     }
 
     #[test]
     fn retry_delay_ignores_unparseable_retry_after() {
         let headers = headers_with_retry_after("Wed, 21 Oct 2015 07:28:00 GMT");
-        let delay = retry_delay(StatusCode::TOO_MANY_REQUESTS, 0, &headers, 3, false, 1);
+        let delay = retry_delay(0, &headers);
         // Falls back to linear backoff
-        assert_eq!(delay, Some(Duration::from_secs(2)));
+        assert_eq!(delay, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn retry_delay_trims_whitespace_in_retry_after() {
+        let headers = headers_with_retry_after("  7  ");
+        let delay = retry_delay(0, &headers);
+        assert_eq!(delay, Duration::from_secs(7));
     }
 
     #[test]
     fn retry_delay_linear_backoff_progression() {
         let headers = empty_headers();
-        assert_eq!(
-            retry_delay(StatusCode::TOO_MANY_REQUESTS, 0, &headers, 5, false, 1),
-            Some(Duration::from_secs(2))
-        );
-        assert_eq!(
-            retry_delay(StatusCode::TOO_MANY_REQUESTS, 1, &headers, 5, false, 1),
-            Some(Duration::from_secs(4))
-        );
-        assert_eq!(
-            retry_delay(StatusCode::TOO_MANY_REQUESTS, 2, &headers, 5, false, 1),
-            Some(Duration::from_secs(6))
-        );
-    }
-
-    #[test]
-    fn retry_delay_exhausted_returns_none() {
-        // budget = 3 means 3 total attempts (attempts 0, 1, 2). After attempt 2,
-        // we should not retry again.
-        let delay = retry_delay(
-            StatusCode::TOO_MANY_REQUESTS,
-            2,
-            &empty_headers(),
-            3,
-            false,
-            1,
-        );
-        assert_eq!(delay, None);
-    }
-
-    #[test]
-    fn retry_delay_200_returns_none() {
-        let delay = retry_delay(StatusCode::OK, 0, &empty_headers(), 3, true, 3);
-        assert_eq!(delay, None);
-    }
-
-    #[test]
-    fn retry_delay_400_returns_none() {
-        let delay = retry_delay(StatusCode::BAD_REQUEST, 0, &empty_headers(), 3, true, 3);
-        assert_eq!(delay, None);
-    }
-
-    #[test]
-    fn retry_delay_500_not_retried_when_disabled() {
-        let delay = retry_delay(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            0,
-            &empty_headers(),
-            3,
-            false,
-            1,
-        );
-        assert_eq!(delay, None);
-    }
-
-    #[test]
-    fn retry_delay_500_retried_when_enabled() {
-        let delay = retry_delay(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            0,
-            &empty_headers(),
-            3,
-            true,
-            2,
-        );
-        assert_eq!(delay, Some(Duration::from_secs(2)));
-    }
-
-    #[test]
-    fn retry_delay_500_exhausts_5xx_budget() {
-        // 5xx budget = 2 means 2 total attempts. After attempt 1, no more retries.
-        let delay = retry_delay(StatusCode::BAD_GATEWAY, 1, &empty_headers(), 3, true, 2);
-        assert_eq!(delay, None);
-    }
-
-    #[test]
-    fn retry_delay_zero_budget_returns_none() {
-        // A budget of 0 means no attempts at all - but the initial call already
-        // happened, so we should just not retry.
-        let delay = retry_delay(
-            StatusCode::TOO_MANY_REQUESTS,
-            0,
-            &empty_headers(),
-            0,
-            false,
-            0,
-        );
-        assert_eq!(delay, None);
+        assert_eq!(retry_delay(0, &headers), Duration::from_secs(2));
+        assert_eq!(retry_delay(1, &headers), Duration::from_secs(4));
+        assert_eq!(retry_delay(2, &headers), Duration::from_secs(6));
     }
 }


### PR DESCRIPTION
## Summary
This PR adds retry logic for upstream requests with configurable backoff, moving timeout configuration into a dedicated config module.

## Key Changes

- **New `config` module**: Extracted configuration into `src/config.rs` with a `ServerConfig` struct that exposes existing listener/timeout settings plus retry-related settings via environment variables:
  - `PROXY_CONNECT_TIMEOUT_SECS` (default: `10`)
  - `PROXY_READ_TIMEOUT_SECS` (default: `600`)
  - `PROXY_MAX_RETRIES` (default: `3`) — max attempts for 429/529 responses and network failures
  - `PROXY_RETRY_ON_5XX` (default: `false`) — enable retries on other 5xx errors
  - `PROXY_5XX_MAX_RETRIES` (default: `1`) — max attempts for 5xx responses

- **Retry logic**: Implemented `execute_with_retry()` which:
  - Retries 429 (Too Many Requests) and 529 (Overloaded) up to `max_retries` attempts
  - Optionally retries other 5xx errors up to `max_5xx_retries` attempts when enabled
  - Retries on transient network errors (timeouts, connection failures)
  - Tracks an **independent retry budget per category** (rate limits / other 5xx / network), so a hiccup in one category does not consume retries reserved for another
  - Respects the `Retry-After` response header (integer seconds, capped at 60s)
  - Falls back to **linear backoff**: `(attempt + 1) * 2` seconds
  - Drains response bodies in a streaming fashion before sleeping so connections return to the pool without buffering large error bodies

- **Cheap body cloning**: The buffered upstream body is passed into the retry loop as `bytes::Bytes`, so cloning per attempt is an `Arc` bump rather than a deep copy of the buffer.

- **Unit tests for `retry_delay()`**: Covering initial-attempt backoff, `Retry-After` parsing, 60s cap, fallback on unparseable values, whitespace trimming, and linear backoff progression.

## Implementation Details

- `retry_delay()` is a pure helper over `(attempt, headers)` — status-based classification and per-category budgets live inline in `execute_with_retry` where the counters are held.
- On HTTP status exhaustion the final upstream response is returned to the caller so the error propagates downstream. The function only panics on non-retryable network errors or when the network retry budget is exhausted, matching the original `.unwrap()` semantics.

https://claude.ai/code/session_01NhGvBAMHv4qiG5PPS1m8nt