### PR TITLE
Add environment variable auth provider and credentials file support

### DIFF
--- a/claude-auth-providers/Cargo.toml
+++ b/claude-auth-providers/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+dirs = "6"
 reqwest = "0.13.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/claude-auth-providers/src/claude_code/credential.rs
+++ b/claude-auth-providers/src/claude_code/credential.rs
@@ -6,7 +6,8 @@ use tracing::{debug, trace};
 #[serde(rename_all = "camelCase")]
 pub struct ClaudeCredential {
     pub access_token: String,
-    pub refresh_token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
     pub expires_at: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subscription_type: Option<String>,

--- a/claude-auth-providers/src/claude_code/credentials_file.rs
+++ b/claude-auth-providers/src/claude_code/credentials_file.rs
@@ -118,7 +118,14 @@ mod tests {
 
     #[test]
     fn returns_empty_for_missing_file() {
-        let path = PathBuf::from("/nonexistent/path/credentials.json");
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "claude-auth-proxy-test-missing-{}.json",
+            std::process::id(),
+        ));
+        // Guarantee the path does not exist (cleans up any prior run).
+        let _ = std::fs::remove_file(&path);
+        assert!(!path.exists());
         assert!(load_from(&path).is_empty());
     }
 

--- a/claude-auth-providers/src/claude_code/credentials_file.rs
+++ b/claude-auth-providers/src/claude_code/credentials_file.rs
@@ -23,7 +23,7 @@ pub fn get_credentials() -> Vec<ClaudeCredential> {
 /// Reads and parses credentials from the given file path. Returns an empty
 /// vec on any failure (missing file, parse error, etc.).
 fn load_from(path: &Path) -> Vec<ClaudeCredential> {
-    let raw = match std::fs::read_to_string(path) {
+    let contents = match std::fs::read_to_string(path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             debug!(path = %path.display(), "Credentials file not found");
@@ -36,7 +36,7 @@ fn load_from(path: &Path) -> Vec<ClaudeCredential> {
     };
 
     #[allow(clippy::option_if_let_else)]
-    if let Some(cred) = parse_credentials(&raw) {
+    if let Some(cred) = parse_credentials(&contents) {
         debug!(path = %path.display(), "Loaded credential from file");
         vec![cred]
     } else {

--- a/claude-auth-providers/src/claude_code/credentials_file.rs
+++ b/claude-auth-providers/src/claude_code/credentials_file.rs
@@ -1,0 +1,133 @@
+use std::path::{Path, PathBuf};
+
+use tracing::{debug, warn};
+
+use crate::claude_code::credential::{ClaudeCredential, parse_credentials};
+
+/// Environment variable that overrides the default credentials file path.
+const CREDENTIALS_FILE_ENV: &str = "CLAUDE_CREDENTIALS_FILE";
+
+/// Reads Claude Code credentials from `~/.claude/.credentials.json` (or the
+/// path specified by `CLAUDE_CREDENTIALS_FILE`).
+///
+/// Returns an empty vec on any failure (missing file, parse error, etc.).
+pub fn get_credentials() -> Vec<ClaudeCredential> {
+    let Some(path) = credentials_file_path() else {
+        debug!("No home directory available; skipping credentials file");
+        return Vec::new();
+    };
+
+    load_from(&path)
+}
+
+/// Reads and parses credentials from the given file path. Returns an empty
+/// vec on any failure (missing file, parse error, etc.).
+fn load_from(path: &Path) -> Vec<ClaudeCredential> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            debug!(path = %path.display(), "Credentials file not found");
+            return Vec::new();
+        }
+        Err(e) => {
+            warn!(path = %path.display(), error = %e, "Failed to read credentials file");
+            return Vec::new();
+        }
+    };
+
+    #[allow(clippy::option_if_let_else)]
+    if let Some(cred) = parse_credentials(&raw) {
+        debug!(path = %path.display(), "Loaded credential from file");
+        vec![cred]
+    } else {
+        warn!(path = %path.display(), "Failed to parse credentials file");
+        Vec::new()
+    }
+}
+
+fn credentials_file_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var(CREDENTIALS_FILE_ENV)
+        && !path.is_empty()
+    {
+        return Some(PathBuf::from(path));
+    }
+
+    let mut path = dirs::home_dir()?;
+    path.push(".claude");
+    path.push(".credentials.json");
+    Some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    fn write_temp_file(name: &str, contents: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "claude-auth-proxy-test-{}-{}.json",
+            name,
+            std::process::id(),
+        ));
+        let mut file = std::fs::File::create(&path).expect("create temp file");
+        file.write_all(contents.as_bytes())
+            .expect("write temp file");
+        path
+    }
+
+    #[test]
+    fn parses_direct_format() {
+        let path = write_temp_file(
+            "direct",
+            r#"{"accessToken":"at","refreshToken":"rt","expiresAt":1000}"#,
+        );
+        let creds = load_from(&path);
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0].access_token, "at");
+        assert_eq!(creds[0].refresh_token.as_deref(), Some("rt"));
+        assert_eq!(creds[0].expires_at, 1000);
+    }
+
+    #[test]
+    fn parses_wrapped_format() {
+        let path = write_temp_file(
+            "wrapped",
+            r#"{"claudeAiOauth":{"accessToken":"at","refreshToken":"rt","expiresAt":1000}}"#,
+        );
+        let creds = load_from(&path);
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0].access_token, "at");
+    }
+
+    #[test]
+    fn parses_without_refresh_token() {
+        let path = write_temp_file("no_refresh", r#"{"accessToken":"at","expiresAt":1000}"#);
+        let creds = load_from(&path);
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0].access_token, "at");
+        assert!(creds[0].refresh_token.is_none());
+    }
+
+    #[test]
+    fn returns_empty_for_missing_file() {
+        let path = PathBuf::from("/nonexistent/path/credentials.json");
+        assert!(load_from(&path).is_empty());
+    }
+
+    #[test]
+    fn returns_empty_for_malformed_json() {
+        let path = write_temp_file("malformed", "not json at all");
+        let creds = load_from(&path);
+        let _ = std::fs::remove_file(&path);
+
+        assert!(creds.is_empty());
+    }
+}

--- a/claude-auth-providers/src/claude_code/mod.rs
+++ b/claude-auth-providers/src/claude_code/mod.rs
@@ -1,10 +1,12 @@
-use std::sync::RwLock;
+use std::{collections::HashSet, sync::RwLock};
 
+#[cfg(target_os = "macos")]
 use tracing::error;
 
 use crate::{ClaudeAuthProvider, Error, claude_code::credential::ClaudeCredential};
 
 mod credential;
+mod credentials_file;
 #[cfg(target_os = "macos")]
 mod keychain;
 mod refresh;
@@ -35,6 +37,7 @@ impl ClaudeCodeAuthProvider {
     fn reload(&self) {
         let mut creds = Vec::new();
 
+        // Source 1: macOS Keychain (macOS only)
         #[cfg(target_os = "macos")]
         {
             let res = keychain::get_credentials();
@@ -45,6 +48,14 @@ impl ClaudeCodeAuthProvider {
                 }
             }
         }
+
+        // Source 2: ~/.claude/.credentials.json (cross-platform fallback)
+        creds.extend(credentials_file::get_credentials());
+
+        // Deduplicate by access_token — keychain and file may contain the
+        // same credential on macOS (Claude Code mirrors to both locations).
+        let mut seen = HashSet::new();
+        creds.retain(|c| seen.insert(c.access_token.clone()));
 
         *self.creds.write().expect("Poisoned Lock") = creds;
     }

--- a/claude-auth-providers/src/claude_code/mod.rs
+++ b/claude-auth-providers/src/claude_code/mod.rs
@@ -52,7 +52,7 @@ impl ClaudeCodeAuthProvider {
         // Source 2: ~/.claude/.credentials.json (cross-platform fallback)
         creds.extend(credentials_file::get_credentials());
 
-        // Deduplicate by access_token — keychain and file may contain the
+        // Deduplicate by access_token: keychain and file may contain the
         // same credential on macOS (Claude Code mirrors to both locations).
         let mut seen = HashSet::new();
         creds.retain(|c| seen.insert(c.access_token.clone()));

--- a/claude-auth-providers/src/claude_code/refresh.rs
+++ b/claude-auth-providers/src/claude_code/refresh.rs
@@ -28,15 +28,17 @@ pub async fn refresh_access_token(
         return Ok(creds);
     }
 
-    // First try refreshing via the API
-    let result = refresh_oauth(&creds.refresh_token).await;
-    if let Ok(cred) = result {
-        // Replacing the old credential with the new one
-        let mut creds_guard = auth.creds.write().expect("Poisoned Lock");
-        *creds_guard
-            .get_mut(auth.active)
-            .expect("Active credential index out of bounds") = cred.clone();
-        return Ok(cred);
+    // First try refreshing via the API (only if we have a refresh token)
+    if let Some(refresh_token) = creds.refresh_token.as_deref() {
+        let result = refresh_oauth(refresh_token).await;
+        if let Ok(cred) = result {
+            // Replacing the old credential with the new one
+            let mut creds_guard = auth.creds.write().expect("Poisoned Lock");
+            *creds_guard
+                .get_mut(auth.active)
+                .expect("Active credential index out of bounds") = cred.clone();
+            return Ok(cred);
+        }
     }
 
     // If that fails, try refreshing via the CLI
@@ -83,7 +85,7 @@ async fn refresh_oauth(refresh_token: &str) -> Result<ClaudeCredential, Error> {
 
     Ok(ClaudeCredential {
         access_token: response.access_token,
-        refresh_token: response.refresh_token.unwrap_or_default(),
+        refresh_token: response.refresh_token,
         expires_at: std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("System time before UNIX EPOCH")

--- a/claude-auth-providers/src/env_var.rs
+++ b/claude-auth-providers/src/env_var.rs
@@ -1,0 +1,41 @@
+use tracing::debug;
+
+use crate::{ClaudeAuthProvider, Error};
+
+/// Environment variable name holding a Claude access token.
+const ACCESS_TOKEN_ENV: &str = "CLAUDE_ACCESS_TOKEN";
+
+/// Auth provider that returns a static access token read from the
+/// `CLAUDE_ACCESS_TOKEN` environment variable.
+///
+/// Intended for CI, Docker, and testing scenarios where an OAuth-based
+/// provider is impractical. There is no refresh path: the token is used
+/// as-is for the lifetime of the process.
+#[derive(Debug)]
+pub struct EnvVarAuthProvider {
+    token: String,
+}
+
+impl EnvVarAuthProvider {
+    /// Constructs a provider from `CLAUDE_ACCESS_TOKEN` if it is set and
+    /// non-empty, otherwise returns `None`.
+    #[must_use]
+    pub fn from_env() -> Option<Self> {
+        let token = std::env::var(ACCESS_TOKEN_ENV).ok()?;
+        if token.is_empty() {
+            return None;
+        }
+        debug!("Loaded access token from {ACCESS_TOKEN_ENV}");
+        Some(Self { token })
+    }
+}
+
+impl ClaudeAuthProvider for EnvVarAuthProvider {
+    async fn get_access_token(&self) -> Result<String, Error> {
+        Ok(self.token.clone())
+    }
+
+    fn has_credentials(&self) -> bool {
+        true
+    }
+}

--- a/claude-auth-providers/src/lib.rs
+++ b/claude-auth-providers/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod claude_code;
+pub mod env_var;
+
+use crate::{claude_code::ClaudeCodeAuthProvider, env_var::EnvVarAuthProvider};
 
 pub trait ClaudeAuthProvider {
     fn get_access_token(&self) -> impl Future<Output = Result<String, Error>>;
@@ -22,4 +25,46 @@ pub enum Error {
     Refresh(String),
     #[error("Spawn Failed: {0}")]
     Spawn(#[from] std::io::Error),
+}
+
+/// Composite auth provider that dispatches to a concrete implementation
+/// chosen at runtime.
+///
+/// The trait's `-> impl Future` return type isn't dyn-compatible, so this
+/// enum provides static dispatch across the available providers.
+#[derive(Debug)]
+pub enum AnyAuthProvider {
+    ClaudeCode(ClaudeCodeAuthProvider),
+    EnvVar(EnvVarAuthProvider),
+}
+
+impl AnyAuthProvider {
+    /// Constructs an auth provider by inspecting the environment.
+    ///
+    /// Prefers `CLAUDE_ACCESS_TOKEN` if set (explicit user override);
+    /// otherwise falls back to `ClaudeCodeAuthProvider`, which reads from
+    /// the macOS Keychain and `~/.claude/.credentials.json`.
+    #[must_use]
+    pub fn from_env() -> Self {
+        EnvVarAuthProvider::from_env().map_or_else(
+            || Self::ClaudeCode(ClaudeCodeAuthProvider::new()),
+            Self::EnvVar,
+        )
+    }
+}
+
+impl ClaudeAuthProvider for AnyAuthProvider {
+    async fn get_access_token(&self) -> Result<String, Error> {
+        match self {
+            Self::ClaudeCode(p) => p.get_access_token().await,
+            Self::EnvVar(p) => p.get_access_token().await,
+        }
+    }
+
+    fn has_credentials(&self) -> bool {
+        match self {
+            Self::ClaudeCode(p) => p.has_credentials(),
+            Self::EnvVar(p) => p.has_credentials(),
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use bytes::Bytes;
-use claude_auth_providers::{ClaudeAuthProvider, claude_code::ClaudeCodeAuthProvider};
+use claude_auth_providers::{AnyAuthProvider, ClaudeAuthProvider};
 use claude_auth_transform::{transform_request, transform_response};
 use http_body_util::BodyExt;
 use reqwest::Client;
@@ -25,7 +25,7 @@ const MAX_RETRY_AFTER: Duration = Duration::from_secs(60);
 
 #[derive(Debug)]
 struct ServerState {
-    auth: ClaudeCodeAuthProvider,
+    auth: AnyAuthProvider,
     client: Client,
     config: ServerConfig,
 }
@@ -50,7 +50,7 @@ async fn main() {
     let host = config.host;
     let port = config.port;
     let state = Arc::new(ServerState {
-        auth: ClaudeCodeAuthProvider::new(),
+        auth: AnyAuthProvider::from_env(),
         client: Client::builder()
             .connect_timeout(config.connect_timeout)
             .read_timeout(config.read_timeout)


### PR DESCRIPTION
## Summary
This PR extends the authentication system to support multiple credential sources and providers. It introduces an environment variable-based auth provider for CI/Docker scenarios and adds cross-platform support for reading credentials from `~/.claude/.credentials.json`.

## Key Changes

- **New `EnvVarAuthProvider`**: Reads `CLAUDE_ACCESS_TOKEN` environment variable for static token-based authentication, suitable for CI, Docker, and testing environments where OAuth is impractical.

- **Credentials file support**: Added `credentials_file.rs` module to read Claude credentials from `~/.claude/.credentials.json` (or path specified by `CLAUDE_CREDENTIALS_FILE` env var). Supports both direct credential format and wrapped `claudeAiOauth` format.

- **Composite `AnyAuthProvider`**: New enum that dispatches to concrete implementations at runtime. Prefers `CLAUDE_ACCESS_TOKEN` if set; otherwise falls back to `ClaudeCodeAuthProvider` (Keychain + credentials file).

- **Improved credential handling**:
  - Made `refresh_token` optional (`Option<String>`) in `ClaudeCredential` to support credentials without refresh capability
  - Added null-check before attempting OAuth refresh in `refresh_oauth`
  - Deduplicates credentials across sources (Keychain and file may contain the same credential on macOS)

- **Updated main server**: Changed from hardcoded `ClaudeCodeAuthProvider` to `AnyAuthProvider::from_env()` for flexible runtime provider selection.

## Implementation Details

- Credentials file parsing gracefully handles missing files and malformed JSON, returning empty credential lists on any failure
- Deduplication uses a `HashSet` keyed by access token to handle cases where the same credential exists in multiple sources
- The `AnyAuthProvider` uses static dispatch (enum) rather than trait objects to work around the `impl Future` return type limitation
- Comprehensive test coverage for credentials file parsing including direct format, wrapped format, missing refresh tokens, and error cases

https://claude.ai/code/session_01BWedrUSwHe8UscpvUzDFYS