### PR TITLE
Migrate config parsing from manual env vars to clap CLI framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ edition = "2024"
 [dependencies]
 axum = "0.8.8"
 bytes = "1"
+clap = { version = "4", features = ["derive", "env"] }
 claude-auth-providers = { version = "0.1.0", path = "claude-auth-providers" }
 claude-auth-transform = { version = "0.1.0", path = "claude-auth-transform" }
 http = "1.4.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,86 +1,84 @@
 use std::{
-    env,
     net::{IpAddr, Ipv4Addr},
-    str::FromStr,
     time::Duration,
 };
 
-/// Runtime configuration for the proxy server, populated from environment
-/// variables on startup.
-#[derive(Debug, Clone)]
+use clap::Args;
+
+/// Runtime configuration for the proxy server.
+///
+/// Values are resolved by clap with the precedence
+/// `CLI flag > environment variable > compiled default`.
+#[derive(Debug, Clone, Args)]
 pub struct ServerConfig {
-    /// Host to bind the HTTP listener on.
+    /// Host address to bind the HTTP listener on.
+    #[arg(
+        long,
+        env = "CLAUDE_PROXY_HOST",
+        default_value_t = IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+    )]
     pub host: IpAddr,
+
     /// Port to bind the HTTP listener on.
+    #[arg(long, env = "CLAUDE_PROXY_PORT", default_value_t = 3000)]
     pub port: u16,
-    /// Connect timeout for upstream requests.
+
+    /// Connect timeout for upstream requests, in seconds.
+    #[arg(
+        long = "connect-timeout",
+        env = "PROXY_CONNECT_TIMEOUT_SECS",
+        value_parser = parse_duration_secs,
+        default_value = "10",
+    )]
     pub connect_timeout: Duration,
-    /// Read timeout for upstream requests.
+
+    /// Read timeout for upstream requests, in seconds.
+    #[arg(
+        long = "read-timeout",
+        env = "PROXY_READ_TIMEOUT_SECS",
+        value_parser = parse_duration_secs,
+        default_value = "600",
+    )]
     pub read_timeout: Duration,
-    /// Maximum number of attempts for 429/529 responses (including the
-    /// initial attempt). A value of `3` means 1 initial attempt + 2 retries.
+
+    /// Maximum number of attempts for 429/529 responses and transient network
+    /// failures (including the initial attempt).
+    #[arg(long, env = "PROXY_MAX_RETRIES", default_value_t = 3)]
     pub max_retries: u32,
-    /// When `true`, 5xx server errors (other than 529) are also retried.
+
+    /// Retry generic 5xx responses (other than 529) up to `max_5xx_retries`.
+    ///
+    /// On the CLI this behaves both as a bare flag (`--retry-on-5xx`) and as
+    /// an explicit value (`--retry-on-5xx=true` / `--retry-on-5xx=false`).
+    /// As an environment variable it accepts the same values the previous
+    /// hand-rolled helper did: `1`/`0`/`true`/`false`/`yes`/`no`.
+    #[arg(
+        long,
+        env = "PROXY_RETRY_ON_5XX",
+        value_parser = parse_bool_flag,
+        num_args = 0..=1,
+        require_equals = true,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub retry_on_5xx: bool,
-    /// Maximum number of attempts for 5xx responses when `retry_on_5xx` is
-    /// enabled. Typically shorter than `max_retries`.
+
+    /// Maximum number of attempts for generic 5xx responses when
+    /// `retry_on_5xx` is enabled. Typically shorter than `max_retries`.
+    #[arg(long, env = "PROXY_5XX_MAX_RETRIES", default_value_t = 1)]
     pub max_5xx_retries: u32,
 }
 
-impl ServerConfig {
-    /// Build a `ServerConfig` from environment variables, falling back to
-    /// sensible defaults when variables are unset or unparseable.
-    #[must_use]
-    pub fn from_env() -> Self {
-        Self {
-            host: parse_or_default("CLAUDE_PROXY_HOST", IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
-            port: parse_or_default("CLAUDE_PROXY_PORT", 3000),
-            connect_timeout: parse_duration_secs("PROXY_CONNECT_TIMEOUT_SECS", 10),
-            read_timeout: parse_duration_secs("PROXY_READ_TIMEOUT_SECS", 600),
-            max_retries: parse_or_default("PROXY_MAX_RETRIES", 3),
-            retry_on_5xx: parse_bool("PROXY_RETRY_ON_5XX", false),
-            max_5xx_retries: parse_or_default("PROXY_5XX_MAX_RETRIES", 1),
-        }
-    }
+fn parse_duration_secs(s: &str) -> Result<Duration, String> {
+    s.parse::<u64>()
+        .map(Duration::from_secs)
+        .map_err(|e| format!("invalid seconds value: {e}"))
 }
 
-fn parse_duration_secs(var: &str, default_secs: u64) -> Duration {
-    Duration::from_secs(parse_or_default(var, default_secs))
-}
-
-/// Read the environment variable `var`, parse it as `T`, and return the
-/// parsed value. If the variable is unset, return `default` silently. If it
-/// is set but cannot be parsed, log a warning and return `default` so a
-/// typo in a critical binding like `CLAUDE_PROXY_HOST` is visible in the
-/// startup logs rather than silently falling back.
-fn parse_or_default<T: FromStr>(var: &str, default: T) -> T {
-    let Ok(raw) = env::var(var) else {
-        return default;
-    };
-    raw.parse::<T>().unwrap_or_else(|_| {
-        tracing::warn!(
-            var,
-            value = %raw,
-            "Environment variable set but could not be parsed, falling back to default"
-        );
-        default
-    })
-}
-
-fn parse_bool(var: &str, default: bool) -> bool {
-    let Ok(raw) = env::var(var) else {
-        return default;
-    };
-    match raw.trim() {
-        "1" | "true" | "TRUE" | "True" | "yes" | "YES" => true,
-        "0" | "false" | "FALSE" | "False" | "no" | "NO" => false,
-        _ => {
-            tracing::warn!(
-                var,
-                value = %raw,
-                "Environment variable set but could not be parsed as a boolean, falling back to default"
-            );
-            default
-        }
+fn parse_bool_flag(s: &str) -> Result<bool, String> {
+    match s.trim() {
+        "1" | "true" | "TRUE" | "True" | "yes" | "YES" => Ok(true),
+        "0" | "false" | "FALSE" | "False" | "no" | "NO" => Ok(false),
+        other => Err(format!("invalid boolean value: {other}")),
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,7 +72,7 @@ pub struct ServerConfig {
 fn parse_duration_secs(s: &str) -> Result<Duration, String> {
     s.parse::<u64>()
         .map(Duration::from_secs)
-        .map_err(|e| format!("invalid seconds value: {e}"))
+        .map_err(|e| format!("invalid seconds value '{s}': {e}"))
 }
 
 fn parse_bool_flag(s: &str) -> Result<bool, String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use bytes::Bytes;
+use clap::{Parser, Subcommand};
 use claude_auth_providers::{AnyAuthProvider, ClaudeAuthProvider};
 use claude_auth_transform::{transform_request, transform_response};
 use http_body_util::BodyExt;
@@ -30,12 +31,35 @@ struct ServerState {
     config: ServerConfig,
 }
 
+#[derive(Parser, Debug)]
+#[command(
+    name = "claude-auth-proxy",
+    version,
+    about,
+    arg_required_else_help = true
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Start the proxy server.
+    Run(ServerConfig),
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let config = ServerConfig::from_env();
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Run(config) => run(config).await,
+    }
+}
 
+async fn run(config: ServerConfig) {
     tracing::info!(
         host = %config.host,
         port = config.port,


### PR DESCRIPTION
## Summary
Refactored the configuration system to use the `clap` CLI framework instead of manual environment variable parsing. This provides better CLI support, automatic help text generation, and cleaner precedence handling (CLI flags > env vars > defaults).

## Key Changes
- **Replaced manual env parsing**: Removed custom `parse_or_default()` and `parse_bool()` helper functions in favor of clap's declarative attribute-based configuration
- **Added clap dependency**: Integrated `clap` with `derive` and `env` features for declarative CLI argument parsing
- **Restructured ServerConfig**: Converted from a struct with a `from_env()` method to a clap `Args` struct with inline attribute configuration for each field
- **Introduced CLI subcommand structure**: Added `Cli` parser with a `Run` subcommand to support future extensibility (e.g., config validation commands)
- **Improved config field documentation**: Enhanced doc comments to clarify units (e.g., "in seconds") and behavior (e.g., retry semantics)
- **Updated main.rs**: Changed initialization from `ServerConfig::from_env()` to `Cli::parse()` with subcommand matching
- **Custom value parsers**: Implemented `parse_duration_secs()` and `parse_bool_flag()` as clap-compatible value parsers with proper error handling

## Notable Implementation Details
- The `retry_on_5xx` boolean flag supports flexible CLI usage: bare flag (`--retry-on-5xx`), explicit values (`--retry-on-5xx=true`), and environment variable compatibility with legacy formats (`1`/`0`/`true`/`false`/`yes`/`no`)
- Configuration precedence is now handled automatically by clap: CLI arguments override environment variables, which override compiled defaults
- Error messages from parsing failures are now returned as `Result` types rather than logged warnings, providing clearer feedback to users

https://claude.ai/code/session_01RCB5VAGjJf2PWrrUsk5BLM