### PR TITLE
Add structured error handling with Anthropic-compatible responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow = "1.0.102"
 axum = "0.8.8"
 bytes = "1"
 clap = { version = "4", features = ["derive", "env"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,12 @@ impl AppError {
         match self {
             Self::BodyCollect(_) | Self::Transform(_) => StatusCode::BAD_REQUEST,
             Self::BuildUri(_) | Self::BuildRequest(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            // `NoCredentials` is local misconfiguration, not an upstream
+            // gateway failure; 503 mirrors the `/ready` handler's response
+            // for the same condition.
+            Self::Auth(claude_auth_providers::Error::NoCredentials) => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
             Self::Auth(_) | Self::Upstream(_) => StatusCode::BAD_GATEWAY,
         }
     }
@@ -70,5 +76,105 @@ impl IntoResponse for AppError {
             },
         }));
         (status, body).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{body::to_bytes, http::StatusCode, response::IntoResponse};
+    use serde_json::Value;
+
+    use super::AppError;
+
+    /// Render an `AppError` through `IntoResponse` and return
+    /// `(status, json_body)` for assertions.
+    async fn render(err: AppError) -> (StatusCode, Value) {
+        let response = err.into_response();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+        let json: Value =
+            serde_json::from_slice(&bytes).expect("response body should be valid JSON");
+        (status, json)
+    }
+
+    /// Assert the Anthropic-compatible error envelope shape.
+    ///
+    /// Matches on the stable message prefix (from our own `#[error("...")]`
+    /// attribute) rather than the full string, so upstream error-crate display
+    /// tweaks don't break the test.
+    fn assert_envelope(json: &Value, expected_type: &str, expected_prefix: &str) {
+        assert_eq!(json["type"], "error", "envelope type");
+        assert_eq!(json["error"]["type"], expected_type, "error.type");
+        let message = json["error"]["message"]
+            .as_str()
+            .expect("error.message should be a string");
+        assert!(
+            message.starts_with(expected_prefix),
+            "expected message to start with {expected_prefix:?}, got {message:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn body_collect_maps_to_400_invalid_request_error() {
+        let source = std::io::Error::new(std::io::ErrorKind::InvalidData, "bad body");
+        let (status, json) = render(AppError::BodyCollect(axum::Error::new(source))).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_envelope(
+            &json,
+            "invalid_request_error",
+            "failed to read request body: ",
+        );
+    }
+
+    #[tokio::test]
+    async fn transform_maps_to_400_invalid_request_error() {
+        let json_err = serde_json::from_str::<i32>("not-a-number").unwrap_err();
+        let err = AppError::Transform(claude_auth_transform::Error::Json(json_err));
+        let (status, json) = render(err).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_envelope(
+            &json,
+            "invalid_request_error",
+            "failed to transform request: ",
+        );
+    }
+
+    #[tokio::test]
+    async fn build_uri_maps_to_500_api_error() {
+        let source = http::Request::builder()
+            .method("not a method")
+            .body(())
+            .expect_err("invalid HTTP method should produce an http::Error");
+        let (status, json) = render(AppError::BuildUri(source)).await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_envelope(&json, "api_error", "failed to build upstream URI: ");
+    }
+
+    #[tokio::test]
+    async fn auth_no_credentials_maps_to_503_api_error() {
+        let err = AppError::Auth(claude_auth_providers::Error::NoCredentials);
+        let (status, json) = render(err).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_envelope(
+            &json,
+            "api_error",
+            "failed to acquire upstream access token: ",
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_other_error_maps_to_502_api_error() {
+        let err = AppError::Auth(claude_auth_providers::Error::Refresh(
+            "network failure".to_string(),
+        ));
+        let (status, json) = render(err).await;
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert_envelope(
+            &json,
+            "api_error",
+            "failed to acquire upstream access token: ",
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,74 @@
+//! Application error type for the request handler.
+//!
+//! Request-handler errors are rendered as HTTP responses that mirror
+//! Anthropic's public API error envelope, so existing Anthropic SDK clients
+//! that hit this proxy can parse and surface the error through their normal
+//! error-handling paths. See <https://docs.anthropic.com/en/api/errors>.
+
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum AppError {
+    #[error("failed to build upstream URI: {0}")]
+    BuildUri(#[source] http::Error),
+
+    #[error("failed to read request body: {0}")]
+    BodyCollect(#[source] axum::Error),
+
+    #[error("failed to acquire upstream access token: {0}")]
+    Auth(#[from] claude_auth_providers::Error),
+
+    #[error("failed to transform request: {0}")]
+    Transform(#[from] claude_auth_transform::Error),
+
+    #[error("failed to build upstream request: {0}")]
+    BuildRequest(#[source] reqwest::Error),
+
+    #[error("upstream request failed: {0}")]
+    Upstream(#[source] reqwest::Error),
+}
+
+impl AppError {
+    /// HTTP status code returned to the client for this error.
+    const fn status_code(&self) -> StatusCode {
+        match self {
+            Self::BodyCollect(_) | Self::Transform(_) => StatusCode::BAD_REQUEST,
+            Self::BuildUri(_) | Self::BuildRequest(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Auth(_) | Self::Upstream(_) => StatusCode::BAD_GATEWAY,
+        }
+    }
+
+    /// Anthropic-compatible `error.type` discriminant.
+    ///
+    /// Anthropic's taxonomy has no `bad_gateway` variant, so upstream /
+    /// auth failures map onto `api_error` (the general server-side failure
+    /// type). Client-payload failures map onto `invalid_request_error`.
+    const fn anthropic_error_type(&self) -> &'static str {
+        match self {
+            Self::BodyCollect(_) | Self::Transform(_) => "invalid_request_error",
+            Self::BuildUri(_) | Self::BuildRequest(_) | Self::Auth(_) | Self::Upstream(_) => {
+                "api_error"
+            }
+        }
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let status = self.status_code();
+        let error_type = self.anthropic_error_type();
+        tracing::error!(error = %self, status = %status, "request failed");
+        let body = Json(serde_json::json!({
+            "type": "error",
+            "error": {
+                "type": error_type,
+                "message": self.to_string(),
+            },
+        }));
+        (status, body).into_response()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod config;
+mod error;
 mod install;
 
 use std::{sync::Arc, time::Duration};
@@ -17,9 +18,9 @@ use claude_auth_transform::{transform_request, transform_response};
 use http_body_util::BodyExt;
 use reqwest::Client;
 use tokio::signal;
-use tracing::{debug, error, info};
+use tracing::{debug, info};
 
-use crate::config::ServerConfig;
+use crate::{config::ServerConfig, error::AppError};
 
 /// Upper bound on honoring a `Retry-After` response header. Protects against a
 /// misbehaving upstream asking the proxy to stall for hours.
@@ -55,7 +56,7 @@ enum Command {
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -65,23 +66,14 @@ async fn main() {
 
     let cli = Cli::parse();
     match cli.command {
-        Command::Run(config) => run(config).await,
-        Command::Install(args) => {
-            if let Err(e) = install::install(args) {
-                error!(error = %e, "install failed");
-                std::process::exit(1);
-            }
-        }
-        Command::Uninstall => {
-            if let Err(e) = install::uninstall() {
-                error!(error = %e, "uninstall failed");
-                std::process::exit(1);
-            }
-        }
+        Command::Run(config) => run(config).await?,
+        Command::Install(args) => install::install(args)?,
+        Command::Uninstall => install::uninstall()?,
     }
+    Ok(())
 }
 
-async fn run(config: ServerConfig) {
+async fn run(config: ServerConfig) -> std::io::Result<()> {
     tracing::info!(
         host = %config.host,
         port = config.port,
@@ -110,13 +102,13 @@ async fn run(config: ServerConfig) {
         .route("/ready", axum::routing::get(ready_handler))
         .route("/v1/{*rest}", axum::routing::any(messages_handler))
         .with_state(state);
-    let listener = tokio::net::TcpListener::bind((host, port)).await.unwrap();
+    let listener = tokio::net::TcpListener::bind((host, port)).await?;
     info!("Listening on {host}:{port}");
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
-        .await
-        .unwrap();
+        .await?;
     info!("Server shutdown complete");
+    Ok(())
 }
 
 async fn shutdown_signal() {
@@ -156,7 +148,10 @@ async fn ready_handler(State(state): State<Arc<ServerState>>) -> impl IntoRespon
     }
 }
 
-async fn messages_handler(State(state): State<Arc<ServerState>>, req: Request) -> Response {
+async fn messages_handler(
+    State(state): State<Arc<ServerState>>,
+    req: Request,
+) -> Result<Response, AppError> {
     let (mut parts, body) = req.into_parts();
     debug!("Received request: {} {}", parts.method, parts.uri);
 
@@ -171,7 +166,7 @@ async fn messages_handler(State(state): State<Arc<ServerState>>, req: Request) -
         .authority("api.anthropic.com")
         .path_and_query(path_and_query)
         .build()
-        .unwrap();
+        .map_err(AppError::BuildUri)?;
 
     parts.headers.remove("host");
     parts.headers.remove("content-length");
@@ -179,12 +174,16 @@ async fn messages_handler(State(state): State<Arc<ServerState>>, req: Request) -
     parts.headers.remove("connection");
     parts.headers.remove("accept-encoding");
 
-    let collected = body.collect().await.unwrap().to_bytes();
+    let collected = body
+        .collect()
+        .await
+        .map_err(AppError::BodyCollect)?
+        .to_bytes();
     let req = http::Request::from_parts(parts, collected);
 
-    let token = state.auth.get_access_token().await.unwrap();
+    let token = state.auth.get_access_token().await?;
 
-    let req = transform_request(req, &token).unwrap();
+    let req = transform_request(req, &token)?;
 
     let (parts, body) = req.into_parts();
     debug!("Forwarding request: {} {}", parts.method, parts.uri);
@@ -192,7 +191,7 @@ async fn messages_handler(State(state): State<Arc<ServerState>>, req: Request) -
     // Convert the body to `Bytes` so that cloning for retries is cheap
     // (reference-counted) instead of deep-copying the Vec on each attempt.
     let body = Bytes::from(body);
-    let res = execute_with_retry(&state, parts, body).await;
+    let res = execute_with_retry(&state, parts, body).await?;
 
     // Convert reqwest::Response -> http::Response with a streaming body
     let status = res.status();
@@ -205,7 +204,7 @@ async fn messages_handler(State(state): State<Arc<ServerState>>, req: Request) -
     *response.headers_mut() = headers;
 
     // Wrap through ClaudeBody to strip tool prefixes from SSE events
-    transform_response(response).map(Body::new)
+    Ok(transform_response(response).map(Body::new))
 }
 
 /// Execute the upstream request with retries for transient failures.
@@ -217,14 +216,14 @@ async fn messages_handler(State(state): State<Arc<ServerState>>, req: Request) -
 /// - Network timeouts / connect errors: up to `config.max_retries` attempts
 ///
 /// On HTTP status exhaustion the final response is returned to the caller so
-/// the upstream error is propagated downstream. This function only panics on
-/// non-retryable network errors or when the network retry budget is exhausted,
-/// matching the existing `.unwrap()` behavior at this call site.
+/// the upstream error is propagated downstream. Non-retryable network failures
+/// and exhaustion of the network retry budget surface as
+/// [`AppError::Upstream`], which the handler renders as a 502 response.
 async fn execute_with_retry(
     state: &ServerState,
     parts: http::request::Parts,
     body: Bytes,
-) -> reqwest::Response {
+) -> Result<reqwest::Response, AppError> {
     // Each retry category has an independent budget: a failure in one
     // category must not consume retries reserved for another.
     let mut rate_limit_attempts: u32 = 0;
@@ -234,7 +233,7 @@ async fn execute_with_retry(
     loop {
         // Cloning `Bytes` is a cheap Arc bump, not a deep copy of the body.
         let http_req = http::Request::from_parts(parts.clone(), body.clone());
-        let reqwest_req = reqwest::Request::try_from(http_req).unwrap();
+        let reqwest_req = reqwest::Request::try_from(http_req).map_err(AppError::BuildRequest)?;
 
         match state.client.execute(reqwest_req).await {
             Ok(mut res) => {
@@ -250,14 +249,14 @@ async fn execute_with_retry(
                 } else if is_other_5xx && state.config.retry_on_5xx {
                     (&mut other_5xx_attempts, state.config.max_5xx_retries)
                 } else {
-                    return res;
+                    return Ok(res);
                 };
 
                 // `*attempt` is 0-indexed and counts the attempt just made.
                 // A budget of N means up to N total attempts, so once the
                 // initial call + prior retries reach the budget we stop.
                 if *attempt + 1 >= budget {
-                    return res;
+                    return Ok(res);
                 }
 
                 let delay = retry_delay(*attempt, res.headers());
@@ -288,7 +287,7 @@ async fn execute_with_retry(
                 tokio::time::sleep(delay).await;
                 network_attempts += 1;
             }
-            Err(e) => panic!("upstream request failed: {e}"),
+            Err(e) => return Err(AppError::Upstream(e)),
         }
     }
 }


### PR DESCRIPTION
## Summary
Introduce a new `AppError` type that provides structured error handling for the request handler, rendering errors as HTTP responses that mirror Anthropic's public API error envelope. This allows existing Anthropic SDK clients to parse and surface errors through their normal error-handling paths.

## Key Changes
- **New `error.rs` module**: Defines `AppError` enum with variants for different failure modes (URI building, body collection, authentication, request transformation, upstream requests)
- **Anthropic-compatible error responses**: Errors are rendered as JSON with `type: "error"` and an `error` object containing `type` and `message` fields, matching Anthropic's API error format
- **Proper HTTP status codes**: Maps error types to appropriate status codes (400 for client errors, 500 for server errors, 502 for upstream/auth failures)
- **Result-based error propagation**: Converts `messages_handler` and `execute_with_retry` to return `Result` types instead of panicking or unwrapping
- **Improved error logging**: Errors are logged with context (status code) before being rendered as responses
- **Graceful error handling in main**: Refactored `main()` and `run()` to use `?` operator with proper error propagation instead of manual error handling and `std::process::exit()`

## Notable Implementation Details
- Error type discrimination uses Anthropic's taxonomy: `invalid_request_error` for client-payload failures, `api_error` for server-side failures
- Network failures and retry budget exhaustion surface as `AppError::Upstream` (502 response) instead of panicking
- The `IntoResponse` trait implementation automatically converts `AppError` to properly formatted HTTP responses
- Added `anyhow` dependency for ergonomic error handling in `main()`

https://claude.ai/code/session_01YPwnmaFvnYg7MsJEYEh3EH