### PR TITLE
Add 401 retry logic with forced credential refresh

### DIFF
--- a/claude-auth-providers/src/claude_code/mod.rs
+++ b/claude-auth-providers/src/claude_code/mod.rs
@@ -72,7 +72,13 @@ impl ClaudeCodeAuthProvider {
 impl ClaudeAuthProvider for ClaudeCodeAuthProvider {
     async fn get_access_token(&self) -> Result<String, Error> {
         let creds = self.get_active_credential().ok_or(Error::NoCredentials)?;
-        let creds = refresh::refresh_access_token(self, creds).await?;
+        let creds = refresh::refresh_access_token(self, creds, false).await?;
+        Ok(creds.access_token)
+    }
+
+    async fn force_refresh_token(&self) -> Result<String, Error> {
+        let creds = self.get_active_credential().ok_or(Error::NoCredentials)?;
+        let creds = refresh::refresh_access_token(self, creds, true).await?;
         Ok(creds.access_token)
     }
 

--- a/claude-auth-providers/src/claude_code/refresh.rs
+++ b/claude-auth-providers/src/claude_code/refresh.rs
@@ -18,13 +18,14 @@ const CLI_TIMEOUT: Duration = Duration::from_secs(60);
 pub async fn refresh_access_token(
     auth: &ClaudeCodeAuthProvider,
     creds: ClaudeCredential,
+    force: bool,
 ) -> Result<ClaudeCredential, Error> {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .expect("System time before UNIX EPOCH")
         .as_secs();
 
-    if now + EXPIRE_BUFFER.as_secs() < creds.expires_at {
+    if !force && now + EXPIRE_BUFFER.as_secs() < creds.expires_at {
         return Ok(creds);
     }
 

--- a/claude-auth-providers/src/lib.rs
+++ b/claude-auth-providers/src/lib.rs
@@ -5,10 +5,13 @@ use crate::{claude_code::ClaudeCodeAuthProvider, env_var::EnvVarAuthProvider};
 
 pub trait ClaudeAuthProvider {
     fn get_access_token(&self) -> impl Future<Output = Result<String, Error>>;
-    /// Force-refresh credentials, bypassing any expiry cache.
+    /// Attempt to force-refresh credentials.
     ///
-    /// Used when upstream returns 401 to obtain a genuinely new token.
-    /// Default implementation delegates to [`get_access_token`](Self::get_access_token).
+    /// Implementations that override this method may bypass any expiry cache
+    /// and obtain a genuinely new token, for example after an upstream 401.
+    /// The default implementation simply delegates to
+    /// [`get_access_token`](Self::get_access_token), so it may still return a
+    /// cached or otherwise non-refreshed token.
     fn force_refresh_token(&self) -> impl Future<Output = Result<String, Error>> {
         self.get_access_token()
     }

--- a/claude-auth-providers/src/lib.rs
+++ b/claude-auth-providers/src/lib.rs
@@ -5,6 +5,13 @@ use crate::{claude_code::ClaudeCodeAuthProvider, env_var::EnvVarAuthProvider};
 
 pub trait ClaudeAuthProvider {
     fn get_access_token(&self) -> impl Future<Output = Result<String, Error>>;
+    /// Force-refresh credentials, bypassing any expiry cache.
+    ///
+    /// Used when upstream returns 401 to obtain a genuinely new token.
+    /// Default implementation delegates to [`get_access_token`](Self::get_access_token).
+    fn force_refresh_token(&self) -> impl Future<Output = Result<String, Error>> {
+        self.get_access_token()
+    }
     fn has_credentials(&self) -> bool {
         true
     }
@@ -58,6 +65,13 @@ impl ClaudeAuthProvider for AnyAuthProvider {
         match self {
             Self::ClaudeCode(p) => p.get_access_token().await,
             Self::EnvVar(p) => p.get_access_token().await,
+        }
+    }
+
+    async fn force_refresh_token(&self) -> Result<String, Error> {
+        match self {
+            Self::ClaudeCode(p) => p.force_refresh_token().await,
+            Self::EnvVar(p) => p.force_refresh_token().await,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use claude_auth_transform::{transform_request, transform_response};
 use http_body_util::BodyExt;
 use reqwest::Client;
 use tokio::signal;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::{config::ServerConfig, error::AppError};
 
@@ -179,19 +179,27 @@ async fn messages_handler(
         .await
         .map_err(AppError::BodyCollect)?
         .to_bytes();
-    let req = http::Request::from_parts(parts, collected);
 
     let token = state.auth.get_access_token().await?;
 
-    let req = transform_request(req, &token)?;
-
-    let (parts, body) = req.into_parts();
-    debug!("Forwarding request: {} {}", parts.method, parts.uri);
+    let req = transform_request(
+        http::Request::from_parts(parts.clone(), collected.clone()),
+        &token,
+    )?;
+    let (tx_parts, tx_body) = req.into_parts();
+    debug!("Forwarding request: {} {}", tx_parts.method, tx_parts.uri);
 
     // Convert the body to `Bytes` so that cloning for retries is cheap
     // (reference-counted) instead of deep-copying the Vec on each attempt.
-    let body = Bytes::from(body);
-    let res = execute_with_retry(&state, parts, body).await?;
+    let tx_body = Bytes::from(tx_body);
+    let res = execute_with_retry(&state, tx_parts, tx_body).await?;
+
+    // On 401, attempt a forced credential refresh and retry once.
+    let res = if res.status() == StatusCode::UNAUTHORIZED {
+        handle_401_retry(&state, &token, parts, collected, res).await?
+    } else {
+        res
+    };
 
     // Convert reqwest::Response -> http::Response with a streaming body
     let status = res.status();
@@ -205,6 +213,52 @@ async fn messages_handler(
 
     // Wrap through ClaudeBody to strip tool prefixes from SSE events
     Ok(transform_response(response).map(Body::new))
+}
+
+/// When upstream returns 401 Unauthorized, attempt a forced credential
+/// refresh and retry the request exactly once with the new token.
+///
+/// If the refreshed token is identical to the original (meaning the
+/// credentials haven't actually changed), or if the refresh itself fails,
+/// the original 401 response is returned to the caller.
+async fn handle_401_retry(
+    state: &ServerState,
+    original_token: &str,
+    parts: http::request::Parts,
+    body: Bytes,
+    original_response: reqwest::Response,
+) -> Result<reqwest::Response, AppError> {
+    debug!("Received 401 from upstream, attempting credential refresh");
+
+    let new_token = match state.auth.force_refresh_token().await {
+        Ok(token) => token,
+        Err(e) => {
+            warn!(error = %e, "Credential refresh failed, returning original 401");
+            return Ok(original_response);
+        }
+    };
+
+    if new_token == original_token {
+        debug!("Refreshed token is identical to original, returning 401 to caller");
+        return Ok(original_response);
+    }
+
+    info!("Credentials refreshed after 401, retrying request with new token");
+
+    // Drain the original 401 response body so the connection returns to the pool.
+    drain_response(original_response).await;
+
+    let req = transform_request(http::Request::from_parts(parts, body), &new_token)?;
+    let (tx_parts, tx_body) = req.into_parts();
+    let tx_body = Bytes::from(tx_body);
+
+    execute_with_retry(state, tx_parts, tx_body).await
+}
+
+/// Drain a response body in a streaming fashion so the underlying connection
+/// can be returned to the pool without buffering in memory.
+async fn drain_response(mut response: reqwest::Response) {
+    while let Ok(Some(_)) = response.chunk().await {}
 }
 
 /// Execute the upstream request with retries for transient failures.

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,20 +245,37 @@ async fn handle_401_retry(
 
     info!("Credentials refreshed after 401, retrying request with new token");
 
-    // Drain the original 401 response body so the connection returns to the pool.
-    drain_response(original_response).await;
-
     let req = transform_request(http::Request::from_parts(parts, body), &new_token)?;
     let (tx_parts, tx_body) = req.into_parts();
     let tx_body = Bytes::from(tx_body);
 
-    execute_with_retry(state, tx_parts, tx_body).await
+    match execute_with_retry(state, tx_parts, tx_body).await {
+        Ok(retry_response) => {
+            // The retry succeeded; drain the original 401 so the connection
+            // can return to the pool.
+            drain_response(original_response).await;
+            Ok(retry_response)
+        }
+        Err(e) => {
+            warn!(error = %e, "Retry after credential refresh failed, returning original 401");
+            Ok(original_response)
+        }
+    }
 }
 
 /// Drain a response body in a streaming fashion so the underlying connection
 /// can be returned to the pool without buffering in memory.
 async fn drain_response(mut response: reqwest::Response) {
-    while let Ok(Some(_)) = response.chunk().await {}
+    loop {
+        match response.chunk().await {
+            Ok(Some(_)) => {}
+            Ok(None) => break,
+            Err(e) => {
+                debug!(error = %e, "Failed to drain response body, connection may not be reused");
+                break;
+            }
+        }
+    }
 }
 
 /// Execute the upstream request with retries for transient failures.


### PR DESCRIPTION
## Summary
This PR adds automatic retry logic when the upstream Claude API returns a 401 Unauthorized response. When a 401 is encountered, the system now attempts to force-refresh credentials and retry the request exactly once with the new token.

## Key Changes

- **New `force_refresh_token()` method**: Added to the `ClaudeAuthProvider` trait with a default implementation that delegates to `get_access_token()`. This allows providers to bypass expiry caches when credentials need to be genuinely refreshed.

- **401 retry handler**: Implemented `handle_401_retry()` function that:
  - Attempts a forced credential refresh when a 401 is received
  - Compares the new token with the original to detect if credentials actually changed
  - Properly drains the original 401 response body to return the connection to the pool
  - Retries the request exactly once with the new token
  - Returns the original 401 response if refresh fails or tokens are identical

- **Response body draining**: Added `drain_response()` utility to stream-drain response bodies without buffering, allowing connections to be returned to the pool efficiently.

- **Claude Code provider updates**: Modified `ClaudeCodeAuthProvider` to support forced refresh by:
  - Adding a `force` parameter to `refresh_access_token()`
  - Bypassing the expiry check when `force=true`
  - Implementing `force_refresh_token()` to call refresh with `force=true`

- **Request cloning for retry**: Modified the main handler to clone request parts and body before transformation, enabling retry attempts with the original request data.

## Implementation Details

- The retry logic is conservative: it only retries once and returns the original 401 if anything goes wrong during refresh
- Token comparison prevents unnecessary retries when credentials haven't actually changed
- Added `warn` logging for credential refresh failures and `info` logging for successful refreshes
- The implementation properly manages connection pooling by draining response bodies before retrying

https://claude.ai/code/session_01Kxoj1RX6TpFuxKzFQdAkmH