### PR TITLE
Refactor transform layer to accept runtime config instead of reading env vars

### DIFF
--- a/claude-auth-transform/src/betas.rs
+++ b/claude-auth-transform/src/betas.rs
@@ -5,13 +5,6 @@ use std::{
 
 use crate::{TransformConfig, config::CONFIG};
 
-fn get_required_betas(config: &TransformConfig) -> Vec<String> {
-    config.beta_flags_override.as_ref().map_or_else(
-        || CONFIG.base_betas.iter().map(|s| (*s).to_owned()).collect(),
-        Clone::clone,
-    )
-}
-
 #[derive(Debug)]
 pub struct BetaManager {
     /// Session-level cache of excluded beta flags per model
@@ -28,7 +21,7 @@ impl BetaManager {
     // TODO: add & clear excluded beta methods
 
     pub fn get_model_betas(&self, model: &str, config: &TransformConfig) -> Vec<String> {
-        let mut betas = get_required_betas(config);
+        let mut betas = config.base_betas.clone();
 
         // TODO: handle 1m context beta
 

--- a/claude-auth-transform/src/betas.rs
+++ b/claude-auth-transform/src/betas.rs
@@ -1,32 +1,21 @@
 use std::{
     collections::{HashMap, HashSet},
-    env,
-    sync::{LazyLock, RwLock},
+    sync::RwLock,
 };
 
-use crate::config::CONFIG;
+use crate::{TransformConfig, config::CONFIG};
 
-static ENV_BETA_FLAGS: LazyLock<Option<String>> =
-    LazyLock::new(|| env::var("ANTHROPIC_BETA_FLAGS").ok());
-
-fn get_required_betas() -> Vec<&'static str> {
-    ENV_BETA_FLAGS.as_deref().map_or_else(
-        || Vec::from(CONFIG.base_betas),
-        |flags| {
-            flags
-                .split(',')
-                .map(str::trim)
-                .filter(|x| !x.is_empty())
-                .collect()
-        },
+fn get_required_betas(config: &TransformConfig) -> Vec<String> {
+    config.beta_flags_override.as_ref().map_or_else(
+        || CONFIG.base_betas.iter().map(|s| (*s).to_owned()).collect(),
+        Clone::clone,
     )
 }
 
-pub static BETA_MANAGER: LazyLock<BetaManager> = LazyLock::new(BetaManager::new);
-
+#[derive(Debug)]
 pub struct BetaManager {
     /// Session-level cache of excluded beta flags per model
-    excluded_betas: RwLock<HashMap<String, HashSet<&'static str>>>,
+    excluded_betas: RwLock<HashMap<String, HashSet<String>>>,
 }
 
 impl BetaManager {
@@ -38,15 +27,15 @@ impl BetaManager {
 
     // TODO: add & clear excluded beta methods
 
-    pub fn get_model_betas(&self, model: &str) -> Vec<&'static str> {
-        let mut betas = get_required_betas();
+    pub fn get_model_betas(&self, model: &str, config: &TransformConfig) -> Vec<String> {
+        let mut betas = get_required_betas(config);
 
         // TODO: handle 1m context beta
 
         // Apply per-model overrides (e.g., haiku excludes claude-code-20250219)
         if let Some(override_) = CONFIG.get_model_override(model) {
-            betas.retain(|b| !override_.exclude.contains(b));
-            betas.extend_from_slice(override_.add);
+            betas.retain(|b| !override_.exclude.contains(&b.as_str()));
+            betas.extend(override_.add.iter().map(|s| (*s).to_owned()));
         }
 
         // Filter out excluded betas (from previous failed requests due to long context errors)

--- a/claude-auth-transform/src/lib.rs
+++ b/claude-auth-transform/src/lib.rs
@@ -14,6 +14,10 @@ use uuid::Uuid;
 
 use crate::{betas::BetaManager, transforms::transform_body};
 
+/// Default CLI version string (from `ModelConfig`). Exposed as a constant
+/// so the main crate can use it for clap default values.
+pub const DEFAULT_CC_VERSION: &str = config::CONFIG.cc_version;
+
 /// Runtime configuration for the transform layer.
 ///
 /// Constructed once at startup from environment variables and defaults.
@@ -28,9 +32,10 @@ pub struct TransformConfig {
     /// Full user-agent override (from `ANTHROPIC_USER_AGENT`). When `None`,
     /// computed as `"claude-cli/{cc_version} (external, cli)"`.
     pub user_agent_override: Option<String>,
-    /// Beta flag override (from `ANTHROPIC_BETA_FLAGS`). When `None`, uses
-    /// `ModelConfig.base_betas`. When `Some`, entirely replaces base betas.
-    pub beta_flags_override: Option<Vec<String>>,
+    /// Resolved base beta flags. When `ANTHROPIC_BETA_FLAGS` is set, this
+    /// holds the parsed override; otherwise it holds `ModelConfig.base_betas`.
+    /// Cached at startup to avoid per-request allocations.
+    pub base_betas: Vec<String>,
     /// Stable per-process session ID.
     pub session_id: String,
 }
@@ -41,27 +46,56 @@ impl Default for TransformConfig {
             cc_version: config::CONFIG.cc_version.to_owned(),
             entrypoint: "cli".to_owned(),
             user_agent_override: None,
-            beta_flags_override: None,
+            base_betas: config::CONFIG
+                .base_betas
+                .iter()
+                .map(|s| (*s).to_owned())
+                .collect(),
             session_id: Uuid::new_v4().to_string(),
         }
     }
 }
 
-/// Bundles [`TransformConfig`] with stateful components ([`BetaManager`]).
+/// Bundles [`TransformConfig`] with stateful components ([`BetaManager`])
+/// and pre-computed header values.
 ///
 /// Created once at startup and shared across requests via `Arc`.
-#[derive(Debug)]
 pub struct TransformContext {
     pub config: TransformConfig,
     beta_manager: BetaManager,
+    /// Pre-computed user-agent header value (avoids per-request formatting).
+    user_agent: HeaderValue,
+}
+
+impl std::fmt::Debug for TransformContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TransformContext")
+            .field("config", &self.config)
+            .field("beta_manager", &self.beta_manager)
+            .field("user_agent", &self.user_agent)
+            .finish()
+    }
 }
 
 impl TransformContext {
+    /// Build a new context, pre-computing the user-agent header value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the resolved user-agent string is not valid ASCII.
     #[must_use]
     pub fn new(config: TransformConfig) -> Self {
+        let user_agent = config.user_agent_override.as_ref().map_or_else(
+            || {
+                HeaderValue::from_str(&format!("claude-cli/{} (external, cli)", config.cc_version))
+                    .expect("User agent must be valid ascii")
+            },
+            |ua| HeaderValue::from_str(ua).expect("User agent must be valid ascii"),
+        );
         Self {
             beta_manager: BetaManager::new(),
             config,
+            user_agent,
         }
     }
 }
@@ -132,17 +166,6 @@ fn build_request_headers(
     let merged_betas =
         HeaderValue::from_str(&merged_betas.join(",")).expect("Betas should all be valid ascii");
 
-    let user_agent = ctx.config.user_agent_override.as_ref().map_or_else(
-        || {
-            HeaderValue::from_str(&format!(
-                "claude-cli/{} (external, cli)",
-                ctx.config.cc_version
-            ))
-            .expect("User agent must be valid ascii")
-        },
-        |ua| HeaderValue::from_str(ua).expect("User agent must be valid ascii"),
-    );
-
     headers.insert(
         "Authorization",
         HeaderValue::from_str(&format!("Bearer {access_token}")).unwrap(),
@@ -150,7 +173,7 @@ fn build_request_headers(
     headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
     headers.insert("anthropic-beta", merged_betas);
     headers.insert("x-app", HeaderValue::from_static("cli"));
-    headers.insert("user-agent", user_agent);
+    headers.insert("user-agent", ctx.user_agent.clone());
     headers.insert(
         "x-client-request-id",
         HeaderValue::from_str(&Uuid::new_v4().to_string()).unwrap(),

--- a/claude-auth-transform/src/lib.rs
+++ b/claude-auth-transform/src/lib.rs
@@ -6,21 +6,65 @@ mod response;
 mod signing;
 mod transforms;
 
-use std::{env, sync::LazyLock};
-
 pub use error::Error;
 use http::{HeaderMap, HeaderValue};
 pub use response::{ClaudeBody, transform_response};
 use tracing::{debug, trace};
 use uuid::Uuid;
 
-use crate::{betas::BETA_MANAGER, config::CONFIG, transforms::transform_body};
+use crate::{betas::BetaManager, transforms::transform_body};
 
-/// Stable per-process session ID, matching Claude Code's X-Claude-Code-Session-Id
-static SESSION_ID: LazyLock<String> = LazyLock::new(|| Uuid::new_v4().to_string());
+/// Runtime configuration for the transform layer.
+///
+/// Constructed once at startup from environment variables and defaults.
+/// The transform crate itself never reads `env::var` — the caller is
+/// responsible for resolving values and passing them in.
+#[derive(Debug, Clone)]
+pub struct TransformConfig {
+    /// CLI version string (from `ANTHROPIC_CLI_VERSION`, default `ModelConfig.cc_version`).
+    pub cc_version: String,
+    /// Entrypoint identifier (from `CLAUDE_CODE_ENTRYPOINT`, default `"cli"`).
+    pub entrypoint: String,
+    /// Full user-agent override (from `ANTHROPIC_USER_AGENT`). When `None`,
+    /// computed as `"claude-cli/{cc_version} (external, cli)"`.
+    pub user_agent_override: Option<String>,
+    /// Beta flag override (from `ANTHROPIC_BETA_FLAGS`). When `None`, uses
+    /// `ModelConfig.base_betas`. When `Some`, entirely replaces base betas.
+    pub beta_flags_override: Option<Vec<String>>,
+    /// Stable per-process session ID.
+    pub session_id: String,
+}
 
-static ENV_VERSION: LazyLock<Option<String>> =
-    LazyLock::new(|| env::var("ANTHROPIC_CLI_VERSION").ok());
+impl Default for TransformConfig {
+    fn default() -> Self {
+        Self {
+            cc_version: config::CONFIG.cc_version.to_owned(),
+            entrypoint: "cli".to_owned(),
+            user_agent_override: None,
+            beta_flags_override: None,
+            session_id: Uuid::new_v4().to_string(),
+        }
+    }
+}
+
+/// Bundles [`TransformConfig`] with stateful components ([`BetaManager`]).
+///
+/// Created once at startup and shared across requests via `Arc`.
+#[derive(Debug)]
+pub struct TransformContext {
+    pub config: TransformConfig,
+    beta_manager: BetaManager,
+}
+
+impl TransformContext {
+    #[must_use]
+    pub fn new(config: TransformConfig) -> Self {
+        Self {
+            beta_manager: BetaManager::new(),
+            config,
+        }
+    }
+}
 
 /// Transform an anthropic API request into a authenticated Claude API request.
 ///
@@ -28,6 +72,7 @@ static ENV_VERSION: LazyLock<Option<String>> =
 ///
 /// * `request`: The HTTP request to transform
 /// * `access_token`: The access token to use for authentication
+/// * `ctx`: Transform context holding runtime config and beta state
 ///
 /// # Errors
 ///
@@ -35,6 +80,7 @@ static ENV_VERSION: LazyLock<Option<String>> =
 pub fn transform_request<B>(
     request: http::Request<B>,
     access_token: &str,
+    ctx: &TransformContext,
 ) -> Result<http::Request<Vec<u8>>, Error>
 where
     B: AsRef<[u8]>,
@@ -48,9 +94,10 @@ where
         &mut parts.headers,
         access_token,
         model_id.as_deref().unwrap_or(""),
+        ctx,
     );
 
-    let body = transform_body(body.as_ref())?;
+    let body = transform_body(body.as_ref(), &ctx.config)?;
 
     trace!(headers = ?parts.headers, "Transformed Headers");
     trace!(body = %String::from_utf8_lossy(&body).as_ref(), "Transformed Body");
@@ -58,26 +105,43 @@ where
     Ok(http::Request::from_parts(parts, body))
 }
 
-fn build_request_headers(headers: &mut HeaderMap, access_token: &str, model_id: &str) {
-    let model_betas = BETA_MANAGER.get_model_betas(model_id);
+fn build_request_headers(
+    headers: &mut HeaderMap,
+    access_token: &str,
+    model_id: &str,
+    ctx: &TransformContext,
+) {
+    let model_betas = ctx.beta_manager.get_model_betas(model_id, &ctx.config);
     trace!(?model_betas, model_id, "Model betas");
     let incoming_beta = headers
         .get("anthropic-beta")
         .map_or("", |v| v.to_str().unwrap_or(""));
     trace!(?incoming_beta, model_id, "Incoming betas");
-    let merged_betas = model_betas
+    let merged_betas: Vec<String> = model_betas
         .into_iter()
         .chain(
             incoming_beta
                 .split(',')
                 .map(str::trim)
-                .filter(|s| !s.is_empty()),
+                .filter(|s| !s.is_empty())
+                .map(String::from),
         )
-        .collect::<Vec<_>>();
+        .collect();
 
     debug!(?merged_betas, model_id, "Computed betas");
     let merged_betas =
         HeaderValue::from_str(&merged_betas.join(",")).expect("Betas should all be valid ascii");
+
+    let user_agent = ctx.config.user_agent_override.as_ref().map_or_else(
+        || {
+            HeaderValue::from_str(&format!(
+                "claude-cli/{} (external, cli)",
+                ctx.config.cc_version
+            ))
+            .expect("User agent must be valid ascii")
+        },
+        |ua| HeaderValue::from_str(ua).expect("User agent must be valid ascii"),
+    );
 
     headers.insert(
         "Authorization",
@@ -86,24 +150,14 @@ fn build_request_headers(headers: &mut HeaderMap, access_token: &str, model_id: 
     headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
     headers.insert("anthropic-beta", merged_betas);
     headers.insert("x-app", HeaderValue::from_static("cli"));
-    headers.insert("user-agent", get_user_agent());
+    headers.insert("user-agent", user_agent);
     headers.insert(
         "x-client-request-id",
         HeaderValue::from_str(&Uuid::new_v4().to_string()).unwrap(),
     );
     headers.insert(
         "X-Claude-Code-Session-Id",
-        HeaderValue::from_str(&SESSION_ID).unwrap(),
+        HeaderValue::from_str(&ctx.config.session_id).unwrap(),
     );
     headers.remove("x-api-key");
-}
-
-fn get_user_agent() -> HeaderValue {
-    HeaderValue::from_str(&env::var("ANTHROPIC_USER_AGENT").unwrap_or_else(|_| {
-        format!(
-            "claude-cli/{} (external, cli)",
-            ENV_VERSION.as_deref().unwrap_or(CONFIG.cc_version)
-        )
-    }))
-    .expect("User agent must be valid ascii")
 }

--- a/claude-auth-transform/src/lib.rs
+++ b/claude-auth-transform/src/lib.rs
@@ -17,7 +17,7 @@ use crate::{betas::BetaManager, transforms::transform_body};
 /// Runtime configuration for the transform layer.
 ///
 /// Constructed once at startup from environment variables and defaults.
-/// The transform crate itself never reads `env::var` — the caller is
+/// The transform crate itself never reads `env::var` -- the caller is
 /// responsible for resolving values and passing them in.
 #[derive(Debug, Clone)]
 pub struct TransformConfig {

--- a/claude-auth-transform/src/transforms.rs
+++ b/claude-auth-transform/src/transforms.rs
@@ -1,32 +1,25 @@
-use std::{
-    collections::{HashMap, HashSet},
-    env,
-    sync::LazyLock,
-};
+use std::collections::{HashMap, HashSet};
 
 use tracing::{debug, trace};
 
 use crate::{
-    ENV_VERSION, Error,
+    TransformConfig, Error,
     bodies::{Message, MessageBody, MessageContent, SystemEntry},
     config::CONFIG,
     signing::build_billing_header_value,
 };
 
-static ENV_ENTRYPOINT: LazyLock<Option<String>> =
-    LazyLock::new(|| env::var("CLAUDE_CODE_ENTRYPOINT").ok());
-
 const SYSTEM_IDENTITY: &str = "You are Claude Code, Anthropic's official CLI for Claude.";
 const TOOL_PREFIX: &str = "mcp_";
 const BILLING_PREFIX: &str = "x-anthropic-billing-header";
 
-pub fn transform_body(bytes: &[u8]) -> Result<Vec<u8>, Error> {
+pub fn transform_body(bytes: &[u8], config: &TransformConfig) -> Result<Vec<u8>, Error> {
     let Ok(mut parsed): Result<MessageBody, _> = serde_json::from_slice(bytes) else {
         debug!("Failed to parse body, skipping transformation");
         return Ok(bytes.to_vec());
     };
 
-    inject_billing_header(&mut parsed);
+    inject_billing_header(&mut parsed, config);
     ensure_identity_prefix(&mut parsed);
     split_identity_entries(&mut parsed);
     relocate_non_core_system_entries(&mut parsed);
@@ -79,9 +72,9 @@ pub fn transform_body(bytes: &[u8]) -> Result<Vec<u8>, Error> {
 }
 
 // --- Billing header: inject as system[0] (no cache_control) ---
-fn inject_billing_header(parsed: &mut MessageBody) {
-    let version = ENV_VERSION.as_deref().unwrap_or(CONFIG.cc_version);
-    let entrypoint = ENV_ENTRYPOINT.as_deref().unwrap_or("cli");
+fn inject_billing_header(parsed: &mut MessageBody, config: &TransformConfig) {
+    let version = &config.cc_version;
+    let entrypoint = &config.entrypoint;
     let billing_header = build_billing_header_value(&parsed.messages, version, entrypoint);
     trace!(billing_header, "Computed billing header");
 
@@ -317,7 +310,8 @@ mod tests {
     #[allow(clippy::needless_pass_by_value)]
     fn run_transform(input: Value) -> Value {
         let bytes = serde_json::to_vec(&input).unwrap();
-        let output = transform_body(&bytes).unwrap();
+        let config = TransformConfig::default();
+        let output = transform_body(&bytes, &config).unwrap();
         serde_json::from_slice(&output).unwrap()
     }
 

--- a/claude-auth-transform/src/transforms.rs
+++ b/claude-auth-transform/src/transforms.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use tracing::{debug, trace};
 
 use crate::{
-    TransformConfig, Error,
+    Error, TransformConfig,
     bodies::{Message, MessageBody, MessageContent, SystemEntry},
     config::CONFIG,
     signing::build_billing_header_value,

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use clap::Args;
+use claude_auth_transform::TransformConfig;
 
 /// Runtime configuration for the proxy server.
 ///
@@ -11,6 +12,9 @@ use clap::Args;
 /// `CLI flag > environment variable > compiled default`.
 #[derive(Debug, Clone, Args)]
 pub struct ServerConfig {
+    #[command(flatten)]
+    pub transform: TransformArgs,
+
     /// Host address to bind the HTTP listener on.
     #[arg(
         long,
@@ -67,6 +71,63 @@ pub struct ServerConfig {
     /// `retry_on_5xx` is enabled. Typically shorter than `max_retries`.
     #[arg(long, env = "PROXY_5XX_MAX_RETRIES", default_value_t = 1)]
     pub max_5xx_retries: u32,
+}
+
+/// Transform-layer configuration parsed from environment variables and CLI
+/// flags via clap. Converted into [`TransformConfig`] for the transform crate.
+#[derive(Debug, Clone, Args)]
+pub struct TransformArgs {
+    /// CLI version string for billing headers.
+    #[arg(
+        long = "cli-version",
+        env = "ANTHROPIC_CLI_VERSION",
+        default_value = claude_auth_transform::DEFAULT_CC_VERSION,
+    )]
+    pub cc_version: String,
+
+    /// Entrypoint identifier for billing headers.
+    #[arg(
+        long = "entrypoint",
+        env = "CLAUDE_CODE_ENTRYPOINT",
+        default_value = "cli"
+    )]
+    pub entrypoint: String,
+
+    /// Override the user-agent header sent to upstream.
+    #[arg(long = "user-agent", env = "ANTHROPIC_USER_AGENT")]
+    pub user_agent_override: Option<String>,
+
+    /// Comma-separated beta flags (replaces defaults when set).
+    #[arg(
+        long = "beta-flags",
+        env = "ANTHROPIC_BETA_FLAGS",
+        value_parser = parse_beta_flags,
+    )]
+    pub beta_flags_override: Option<Vec<String>>,
+}
+
+impl TransformArgs {
+    /// Convert into a [`TransformConfig`] suitable for the transform crate.
+    pub fn into_transform_config(self) -> TransformConfig {
+        let default = TransformConfig::default();
+        TransformConfig {
+            cc_version: self.cc_version,
+            entrypoint: self.entrypoint,
+            user_agent_override: self.user_agent_override,
+            base_betas: self.beta_flags_override.unwrap_or(default.base_betas),
+            ..default
+        }
+    }
+}
+
+/// Clap `value_parser` requires `Result`; this never fails.
+#[allow(clippy::unnecessary_wraps)]
+fn parse_beta_flags(s: &str) -> Result<Vec<String>, String> {
+    Ok(s.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect())
 }
 
 fn parse_duration_secs(s: &str) -> Result<Duration, String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use axum::{
 use bytes::Bytes;
 use clap::{Parser, Subcommand};
 use claude_auth_providers::{AnyAuthProvider, ClaudeAuthProvider};
-use claude_auth_transform::{transform_request, transform_response};
+use claude_auth_transform::{TransformConfig, TransformContext, transform_request, transform_response};
 use http_body_util::BodyExt;
 use reqwest::Client;
 use tokio::signal;
@@ -31,6 +31,7 @@ struct ServerState {
     auth: AnyAuthProvider,
     client: Client,
     config: ServerConfig,
+    transform: TransformContext,
 }
 
 #[derive(Parser, Debug)]
@@ -85,6 +86,33 @@ async fn run(config: ServerConfig) -> std::io::Result<()> {
         "Proxy configuration"
     );
 
+    let mut transform_config = TransformConfig::default();
+    if let Ok(v) = std::env::var("ANTHROPIC_CLI_VERSION") {
+        transform_config.cc_version = v;
+    }
+    if let Ok(v) = std::env::var("CLAUDE_CODE_ENTRYPOINT") {
+        transform_config.entrypoint = v;
+    }
+    transform_config.user_agent_override = std::env::var("ANTHROPIC_USER_AGENT").ok();
+    transform_config.beta_flags_override =
+        std::env::var("ANTHROPIC_BETA_FLAGS").ok().map(|flags| {
+            flags
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+                .collect()
+        });
+
+    tracing::info!(
+        cc_version = %transform_config.cc_version,
+        entrypoint = %transform_config.entrypoint,
+        user_agent_override = ?transform_config.user_agent_override,
+        beta_flags_override = ?transform_config.beta_flags_override,
+        session_id = %transform_config.session_id,
+        "Transform configuration"
+    );
+
     let host = config.host;
     let port = config.port;
     let state = Arc::new(ServerState {
@@ -95,6 +123,7 @@ async fn run(config: ServerConfig) -> std::io::Result<()> {
             .build()
             .expect("failed to build HTTP client"),
         config,
+        transform: TransformContext::new(transform_config),
     });
 
     let app = Router::new()
@@ -185,6 +214,7 @@ async fn messages_handler(
     let req = transform_request(
         http::Request::from_parts(parts.clone(), collected.clone()),
         &token,
+        &state.transform,
     )?;
     let (tx_parts, tx_body) = req.into_parts();
     debug!("Forwarding request: {} {}", tx_parts.method, tx_parts.uri);
@@ -245,7 +275,11 @@ async fn handle_401_retry(
 
     info!("Credentials refreshed after 401, retrying request with new token");
 
-    let req = transform_request(http::Request::from_parts(parts, body), &new_token)?;
+    let req = transform_request(
+        http::Request::from_parts(parts, body),
+        &new_token,
+        &state.transform,
+    )?;
     let (tx_parts, tx_body) = req.into_parts();
     let tx_body = Bytes::from(tx_body);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,9 @@ use axum::{
 use bytes::Bytes;
 use clap::{Parser, Subcommand};
 use claude_auth_providers::{AnyAuthProvider, ClaudeAuthProvider};
-use claude_auth_transform::{TransformConfig, TransformContext, transform_request, transform_response};
+use claude_auth_transform::{
+    TransformConfig, TransformContext, transform_request, transform_response,
+};
 use http_body_util::BodyExt;
 use reqwest::Client;
 use tokio::signal;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,7 @@ use axum::{
 use bytes::Bytes;
 use clap::{Parser, Subcommand};
 use claude_auth_providers::{AnyAuthProvider, ClaudeAuthProvider};
-use claude_auth_transform::{
-    TransformConfig, TransformContext, transform_request, transform_response,
-};
+use claude_auth_transform::{TransformContext, transform_request, transform_response};
 use http_body_util::BodyExt;
 use reqwest::Client;
 use tokio::signal;
@@ -88,35 +86,23 @@ async fn run(config: ServerConfig) -> std::io::Result<()> {
         "Proxy configuration"
     );
 
-    let mut transform_config = TransformConfig::default();
-    if let Ok(v) = std::env::var("ANTHROPIC_CLI_VERSION") {
-        transform_config.cc_version = v;
-    }
-    if let Ok(v) = std::env::var("CLAUDE_CODE_ENTRYPOINT") {
-        transform_config.entrypoint = v;
-    }
-    transform_config.user_agent_override = std::env::var("ANTHROPIC_USER_AGENT").ok();
-    transform_config.beta_flags_override =
-        std::env::var("ANTHROPIC_BETA_FLAGS").ok().map(|flags| {
-            flags
-                .split(',')
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(String::from)
-                .collect()
-        });
+    let transform_config = config.transform.clone().into_transform_config();
 
     tracing::info!(
         cc_version = %transform_config.cc_version,
         entrypoint = %transform_config.entrypoint,
         user_agent_override = ?transform_config.user_agent_override,
-        beta_flags_override = ?transform_config.beta_flags_override,
-        session_id = %transform_config.session_id,
+        base_betas = ?transform_config.base_betas,
         "Transform configuration"
+    );
+    tracing::debug!(
+        session_id = %transform_config.session_id,
+        "Transform session"
     );
 
     let host = config.host;
     let port = config.port;
+    let transform = TransformContext::new(transform_config);
     let state = Arc::new(ServerState {
         auth: AnyAuthProvider::from_env(),
         client: Client::builder()
@@ -125,7 +111,7 @@ async fn run(config: ServerConfig) -> std::io::Result<()> {
             .build()
             .expect("failed to build HTTP client"),
         config,
-        transform: TransformContext::new(transform_config),
+        transform,
     });
 
     let app = Router::new()


### PR DESCRIPTION
## Summary

This PR refactors the `claude-auth-transform` crate to eliminate direct environment variable reads and instead accept runtime configuration through a new `TransformConfig` struct. This improves testability, makes configuration explicit, and follows dependency injection principles.

## Key Changes

- **New `TransformConfig` struct**: Encapsulates all runtime configuration (cc_version, entrypoint, user_agent_override, beta_flags_override, session_id) that was previously read from environment variables or static defaults
- **New `TransformContext` struct**: Bundles `TransformConfig` with stateful components (`BetaManager`), created once at startup and passed to request handlers
- **Updated `transform_request()` signature**: Now accepts `&TransformContext` parameter instead of reading env vars internally
- **Removed static lazy-initialized env vars**: Eliminated `SESSION_ID`, `ENV_VERSION`, `ENV_BETA_FLAGS`, and `ENV_ENTRYPOINT` static variables
- **Updated `BetaManager`**: Now accepts `&TransformConfig` in `get_model_betas()` to access beta flag overrides; changed return types from `Vec<&'static str>` to `Vec<String>` for flexibility
- **Updated `transform_body()`**: Now accepts `&TransformConfig` parameter to access version and entrypoint
- **Server initialization**: Added explicit configuration resolution in `main.rs` where environment variables are read once at startup and passed to `TransformContext`

## Implementation Details

- Configuration is resolved in `main.rs` by reading environment variables and building a `TransformConfig`, which is then wrapped in `TransformContext` and stored in `ServerState`
- The transform context is passed to `transform_request()` on each request, eliminating the need for global state
- `TransformConfig` implements `Default` to provide sensible defaults when environment variables are not set
- All string allocations for beta flags are now owned `String` types rather than static string references, allowing dynamic configuration
- Tests updated to explicitly construct `TransformConfig::default()` when calling transform functions

https://claude.ai/code/session_013yiNT4VV469vuqakrCLy6E