### PR TITLE
PascalCase tool names to match claude code

### DIFF
--- a/claude-auth-transform/src/response.rs
+++ b/claude-auth-transform/src/response.rs
@@ -13,9 +13,10 @@ static TOOL_PREFIX_RE: std::sync::LazyLock<Regex> =
     std::sync::LazyLock::new(|| Regex::new(r#""name"\s*:\s*"mcp_([^"]+)""#).unwrap());
 
 fn unprefix_tool_name(name: &str) -> String {
-    let Some((first, rest)) = name.split_at_checked(1) else {
+    let Some(first) = name.chars().next() else {
         return String::new();
     };
+    let rest = &name[first.len_utf8()..];
     format!("{}{rest}", first.to_ascii_lowercase())
 }
 

--- a/claude-auth-transform/src/response.rs
+++ b/claude-auth-transform/src/response.rs
@@ -12,6 +12,13 @@ use tracing::{debug, trace};
 static TOOL_PREFIX_RE: std::sync::LazyLock<Regex> =
     std::sync::LazyLock::new(|| Regex::new(r#""name"\s*:\s*"mcp_([^"]+)""#).unwrap());
 
+fn unprefix_tool_name(name: &str) -> String {
+    let Some((first, rest)) = name.split_at_checked(1) else {
+        return String::new();
+    };
+    format!("{}{rest}", first.to_ascii_lowercase())
+}
+
 pub fn transform_response<B>(response: Response<B>) -> Response<ClaudeBody<B>>
 where
     B: Body,
@@ -25,7 +32,9 @@ where
 /// Strips `"name": "mcp_<tool>"` -> `"name": "<tool>"` from a byte slice.
 fn strip_tool_prefix(input: &[u8]) -> Bytes {
     let text = String::from_utf8_lossy(input);
-    let result = TOOL_PREFIX_RE.replace_all(&text, r#""name": "$1""#);
+    let result = TOOL_PREFIX_RE.replace_all(&text, |caps: &regex::Captures<'_>| {
+        format!(r#""name": "{}""#, unprefix_tool_name(&caps[1]))
+    });
     Bytes::from(result.into_owned())
 }
 
@@ -123,14 +132,14 @@ mod tests {
 
     #[test]
     fn strip_prefix_from_name_field() {
-        let input = r#"{"name": "mcp_search", "id": "123"}"#;
+        let input = r#"{"name": "mcp_Search", "id": "123"}"#;
         let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
         assert_eq!(result, r#"{"name": "search", "id": "123"}"#);
     }
 
     #[test]
     fn strip_prefix_multiple_occurrences() {
-        let input = r#"{"name": "mcp_foo"} {"name": "mcp_bar"}"#;
+        let input = r#"{"name": "mcp_Foo"} {"name": "mcp_Bar"}"#;
         let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
         assert_eq!(result, r#"{"name": "foo"} {"name": "bar"}"#);
     }
@@ -144,16 +153,23 @@ mod tests {
 
     #[test]
     fn strip_prefix_with_whitespace_around_colon() {
-        let input = r#"{"name" : "mcp_tool"}"#;
+        let input = r#"{"name" : "mcp_Tool"}"#;
         let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
         assert_eq!(result, r#"{"name": "tool"}"#);
     }
 
     #[test]
     fn does_not_strip_non_name_fields() {
-        let input = r#"{"id": "mcp_123", "name": "mcp_tool"}"#;
+        let input = r#"{"id": "mcp_123", "name": "mcp_Tool"}"#;
         let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
         assert_eq!(result, r#"{"id": "mcp_123", "name": "tool"}"#);
+    }
+
+    #[test]
+    fn strip_prefix_restores_snake_case_after_pascal_case_prefix() {
+        let input = r#"{"name": "mcp_Background_output"}"#;
+        let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
+        assert_eq!(result, r#"{"name": "background_output"}"#);
     }
 
     #[test]

--- a/claude-auth-transform/src/transforms.rs
+++ b/claude-auth-transform/src/transforms.rs
@@ -14,9 +14,10 @@ const TOOL_PREFIX: &str = "mcp_";
 const BILLING_PREFIX: &str = "x-anthropic-billing-header";
 
 fn prefix_tool_name(name: &str) -> String {
-    let Some((first, rest)) = name.split_at_checked(1) else {
+    let Some(first) = name.chars().next() else {
         return TOOL_PREFIX.to_owned();
     };
+    let rest = &name[first.len_utf8()..];
     format!("{TOOL_PREFIX}{}{rest}", first.to_ascii_uppercase())
 }
 

--- a/claude-auth-transform/src/transforms.rs
+++ b/claude-auth-transform/src/transforms.rs
@@ -13,6 +13,13 @@ const SYSTEM_IDENTITY: &str = "You are Claude Code, Anthropic's official CLI for
 const TOOL_PREFIX: &str = "mcp_";
 const BILLING_PREFIX: &str = "x-anthropic-billing-header";
 
+fn prefix_tool_name(name: &str) -> String {
+    let Some((first, rest)) = name.split_at_checked(1) else {
+        return TOOL_PREFIX.to_owned();
+    };
+    format!("{TOOL_PREFIX}{}{rest}", first.to_ascii_uppercase())
+}
+
 pub fn transform_body(bytes: &[u8], config: &TransformConfig) -> Result<Vec<u8>, Error> {
     let Ok(mut parsed): Result<MessageBody, _> = serde_json::from_slice(bytes) else {
         debug!("Failed to parse body, skipping transformation");
@@ -39,17 +46,18 @@ pub fn transform_body(bytes: &[u8], config: &TransformConfig) -> Result<Vec<u8>,
         parsed.thinking.remove("effort");
     }
 
-    // Prefix all tool names with a reserved prefix
+    // Anthropic validates Claude Code tool names as PascalCase after the
+    // reserved mcp_ prefix (for example mcp_Bash instead of mcp_bash).
     parsed.tools.iter_mut().for_each(|tool| {
         if let Some(name) = tool.name.as_mut() {
-            name.insert_str(0, TOOL_PREFIX);
+            *name = prefix_tool_name(name);
         }
     });
 
     if let Some(tool_choice) = parsed.tool_choice.as_mut()
         && let Some(name) = tool_choice.name.as_mut()
     {
-        name.insert_str(0, TOOL_PREFIX);
+        *name = prefix_tool_name(name);
     }
 
     for message in &mut parsed.messages {
@@ -60,12 +68,9 @@ pub fn transform_body(bytes: &[u8], config: &TransformConfig) -> Result<Vec<u8>,
                     && let Some(name) = block.extra.get_mut("name")
                     && name.is_string()
                 {
-                    *name = format!(
-                        "{}{}",
-                        TOOL_PREFIX,
-                        name.as_str().expect("name already checked as string")
-                    )
-                    .into();
+                    *name =
+                        prefix_tool_name(name.as_str().expect("name already checked as string"))
+                            .into();
                 }
             }
         }
@@ -321,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn transform_body_moves_non_core_system_text_and_prefixes_tool_names() {
+    fn transform_body_moves_non_core_system_text_and_pascal_cases_tool_names() {
         let input = json!({
             "system": [{ "type": "text", "text": "OpenCode and opencode" }],
             "tools": [{ "name": "search" }],
@@ -345,8 +350,8 @@ mod tests {
             parsed["messages"][0]["content"][0]["text"],
             "OpenCode and opencode"
         );
-        assert_eq!(parsed["tools"][0]["name"], "mcp_search");
-        assert_eq!(parsed["messages"][0]["content"][1]["name"], "mcp_lookup");
+        assert_eq!(parsed["tools"][0]["name"], "mcp_Search");
+        assert_eq!(parsed["messages"][0]["content"][1]["name"], "mcp_Lookup");
     }
 
     #[test]
@@ -664,7 +669,7 @@ mod tests {
         let parsed = run_transform(input);
 
         assert_eq!(parsed["tool_choice"]["type"], "tool");
-        assert_eq!(parsed["tool_choice"]["name"], "mcp_get_weather");
+        assert_eq!(parsed["tool_choice"]["name"], "mcp_Get_weather");
     }
 
     #[test]
@@ -729,10 +734,10 @@ mod tests {
 
         let parsed = run_transform(input);
 
-        assert_eq!(parsed["tools"][0]["name"], "mcp_search");
-        assert_eq!(parsed["tools"][1]["name"], "mcp_analyze");
+        assert_eq!(parsed["tools"][0]["name"], "mcp_Search");
+        assert_eq!(parsed["tools"][1]["name"], "mcp_Analyze");
         assert_eq!(parsed["tool_choice"]["type"], "tool");
-        assert_eq!(parsed["tool_choice"]["name"], "mcp_analyze");
+        assert_eq!(parsed["tool_choice"]["name"], "mcp_Analyze");
     }
 
     #[test]
@@ -750,7 +755,7 @@ mod tests {
         let parsed = run_transform(input);
 
         assert_eq!(parsed["tool_choice"]["type"], "tool");
-        assert_eq!(parsed["tool_choice"]["name"], "mcp_analyze");
+        assert_eq!(parsed["tool_choice"]["name"], "mcp_Analyze");
         assert_eq!(parsed["tool_choice"]["disable_parallel_tool_use"], true);
     }
 }


### PR DESCRIPTION
Derived from:
https://github.com/griffinmartin/opencode-claude-auth/commit/9121ca47a5e9757e041aea240a29c10e4dfabf95
