### PR TITLE
fix: obfuscate tool names in proxy transforms

### DIFF
--- a/claude-auth-transform/Cargo.toml
+++ b/claude-auth-transform/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+bimap = "0.6.3"
 bytes = "1.11.1"
 hex = "0.4.3"
 http = "1.4.0"

--- a/claude-auth-transform/src/error.rs
+++ b/claude-auth-transform/src/error.rs
@@ -12,4 +12,6 @@ pub enum Error {
     InvalidBetas(#[source] InvalidHeaderValue),
     #[error("failed to serialize JSON: {0}")]
     Json(#[source] serde_json::Error),
+    #[error("invalid tool-name hash bounds: {0}")]
+    InvalidToolNameHashBounds(String),
 }

--- a/claude-auth-transform/src/lib.rs
+++ b/claude-auth-transform/src/lib.rs
@@ -7,10 +7,11 @@ mod signing;
 mod tool_names;
 mod transforms;
 
+use std::sync::Arc;
+
 pub use error::Error;
 use http::{HeaderMap, HeaderValue};
 pub use response::{ClaudeBody, transform_response};
-use std::sync::Arc;
 use tool_names::ToolNameMapper;
 use tracing::{debug, trace};
 use uuid::Uuid;

--- a/claude-auth-transform/src/lib.rs
+++ b/claude-auth-transform/src/lib.rs
@@ -4,11 +4,14 @@ mod config;
 mod error;
 mod response;
 mod signing;
+mod tool_names;
 mod transforms;
 
 pub use error::Error;
 use http::{HeaderMap, HeaderValue};
 pub use response::{ClaudeBody, transform_response};
+use std::sync::Arc;
+use tool_names::ToolNameMapper;
 use tracing::{debug, trace};
 use uuid::Uuid;
 
@@ -38,6 +41,10 @@ pub struct TransformConfig {
     pub base_betas: Vec<String>,
     /// Stable per-process session ID.
     pub session_id: String,
+    /// Minimum number of hex characters to use when obfuscating tool names.
+    pub tool_name_hash_len: usize,
+    /// Maximum number of hex characters to use when obfuscating tool names.
+    pub tool_name_max_hash_len: usize,
 }
 
 impl Default for TransformConfig {
@@ -52,6 +59,8 @@ impl Default for TransformConfig {
                 .map(|s| (*s).to_owned())
                 .collect(),
             session_id: Uuid::new_v4().to_string(),
+            tool_name_hash_len: 8,
+            tool_name_max_hash_len: 16,
         }
     }
 }
@@ -63,6 +72,7 @@ impl Default for TransformConfig {
 pub struct TransformContext {
     pub config: TransformConfig,
     beta_manager: BetaManager,
+    tool_name_mapper: Arc<ToolNameMapper>,
     /// Pre-computed user-agent header value (avoids per-request formatting).
     user_agent: HeaderValue,
 }
@@ -72,6 +82,7 @@ impl std::fmt::Debug for TransformContext {
         f.debug_struct("TransformContext")
             .field("config", &self.config)
             .field("beta_manager", &self.beta_manager)
+            .field("tool_name_mapper", &self.tool_name_mapper)
             .field("user_agent", &self.user_agent)
             .finish()
     }
@@ -84,6 +95,13 @@ impl TransformContext {
     ///
     /// Errors if the resolved user-agent string is not valid ASCII.
     pub fn new(config: TransformConfig) -> Result<Self, Error> {
+        if config.tool_name_hash_len > config.tool_name_max_hash_len {
+            return Err(Error::InvalidToolNameHashBounds(format!(
+                "min {} exceeds max {}",
+                config.tool_name_hash_len, config.tool_name_max_hash_len
+            )));
+        }
+
         let user_agent = config
             .user_agent_override
             .as_ref()
@@ -99,9 +117,17 @@ impl TransformContext {
             .map_err(Error::InvalidUserAgent)?;
         Ok(Self {
             beta_manager: BetaManager::new(),
+            tool_name_mapper: Arc::new(ToolNameMapper::new(
+                config.tool_name_hash_len,
+                config.tool_name_max_hash_len,
+            )),
             config,
             user_agent,
         })
+    }
+
+    pub fn tool_name_mapper(&self) -> Arc<ToolNameMapper> {
+        Arc::clone(&self.tool_name_mapper)
     }
 }
 
@@ -136,7 +162,7 @@ where
         ctx,
     )?;
 
-    let body = transform_body(body.as_ref(), &ctx.config)?;
+    let body = transform_body(body.as_ref(), &ctx.config, &ctx.tool_name_mapper)?;
 
     trace!(headers = ?parts.headers, "Transformed Headers");
     trace!(body = %String::from_utf8_lossy(&body).as_ref(), "Transformed Body");

--- a/claude-auth-transform/src/response.rs
+++ b/claude-auth-transform/src/response.rs
@@ -1,5 +1,6 @@
 use std::{
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -9,31 +10,30 @@ use http_body::{Body, Frame, SizeHint};
 use regex::Regex;
 use tracing::{debug, trace};
 
+use crate::tool_names::ToolNameMapper;
+
 static TOOL_PREFIX_RE: std::sync::LazyLock<Regex> =
-    std::sync::LazyLock::new(|| Regex::new(r#""name"\s*:\s*"mcp_([^"]+)""#).unwrap());
+    std::sync::LazyLock::new(|| Regex::new(r#""name"\s*:\s*"(t_[0-9a-f]+)""#).unwrap());
 
-fn unprefix_tool_name(name: &str) -> String {
-    let Some((first, rest)) = name.split_at_checked(1) else {
-        return String::new();
-    };
-    format!("{}{rest}", first.to_ascii_lowercase())
-}
-
-pub fn transform_response<B>(response: Response<B>) -> Response<ClaudeBody<B>>
+pub fn transform_response<B>(
+    response: Response<B>,
+    tool_name_mapper: Arc<ToolNameMapper>,
+) -> Response<ClaudeBody<B>>
 where
     B: Body,
 {
     response.map(|body| ClaudeBody {
         inner: body,
         buffer: BytesMut::new(),
+        tool_name_mapper,
     })
 }
 
-/// Strips `"name": "mcp_<tool>"` -> `"name": "<tool>"` from a byte slice.
-fn strip_tool_prefix(input: &[u8]) -> Bytes {
+/// Strips `"name": "t_<hash>"` -> `"name": "<tool>"` from a byte slice.
+fn strip_tool_prefix(input: &[u8], tool_name_mapper: &ToolNameMapper) -> Bytes {
     let text = String::from_utf8_lossy(input);
     let result = TOOL_PREFIX_RE.replace_all(&text, |caps: &regex::Captures<'_>| {
-        format!(r#""name": "{}""#, unprefix_tool_name(&caps[1]))
+        format!(r#""name": "{}""#, tool_name_mapper.deobfuscate(&caps[1]))
     });
     Bytes::from(result.into_owned())
 }
@@ -54,6 +54,7 @@ pub struct ClaudeBody<B> {
     inner: B,
     /// SSE line buffer for reassembling partial events
     buffer: BytesMut,
+    tool_name_mapper: Arc<ToolNameMapper>,
 }
 
 impl<B> Body for ClaudeBody<B>
@@ -76,7 +77,7 @@ where
             if let Some(boundary) = find_double_newline(this.buffer) {
                 let event_bytes = this.buffer.split_to(boundary + 2);
                 trace!(raw = %String::from_utf8_lossy(&event_bytes), "Raw SSE event");
-                let stripped = strip_tool_prefix(&event_bytes);
+                let stripped = strip_tool_prefix(&event_bytes, this.tool_name_mapper.as_ref());
                 return Poll::Ready(Some(Ok(Frame::data(stripped))));
             }
 
@@ -105,7 +106,8 @@ where
                     if !this.buffer.is_empty() {
                         let remaining = this.buffer.split();
                         trace!(raw = %String::from_utf8_lossy(&remaining), "Flushing remaining buffer");
-                        let stripped = strip_tool_prefix(&remaining);
+                        let stripped =
+                            strip_tool_prefix(&remaining, this.tool_name_mapper.as_ref());
                         return Poll::Ready(Some(Ok(Frame::data(stripped))));
                     }
                     debug!("Response body complete");
@@ -132,43 +134,67 @@ mod tests {
 
     #[test]
     fn strip_prefix_from_name_field() {
-        let input = r#"{"name": "mcp_Search", "id": "123"}"#;
-        let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
+        let tool_name_mapper = ToolNameMapper::new(8, 16);
+        let obfuscated = tool_name_mapper.obfuscate("search");
+        let input = format!(r#"{{"name": "{obfuscated}", "id": "123"}}"#);
+        let result =
+            String::from_utf8(strip_tool_prefix(input.as_bytes(), &tool_name_mapper).to_vec())
+                .unwrap();
         assert_eq!(result, r#"{"name": "search", "id": "123"}"#);
     }
 
     #[test]
     fn strip_prefix_multiple_occurrences() {
-        let input = r#"{"name": "mcp_Foo"} {"name": "mcp_Bar"}"#;
-        let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
+        let tool_name_mapper = ToolNameMapper::new(8, 16);
+        let foo = tool_name_mapper.obfuscate("foo");
+        let bar = tool_name_mapper.obfuscate("bar");
+        let input = format!(r#"{{"name": "{foo}"}} {{"name": "{bar}"}}"#);
+        let result =
+            String::from_utf8(strip_tool_prefix(input.as_bytes(), &tool_name_mapper).to_vec())
+                .unwrap();
         assert_eq!(result, r#"{"name": "foo"} {"name": "bar"}"#);
     }
 
     #[test]
     fn no_prefix_unchanged() {
         let input = r#"{"name": "search", "id": "123"}"#;
-        let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
+        let result = String::from_utf8(
+            strip_tool_prefix(input.as_bytes(), &ToolNameMapper::new(8, 16)).to_vec(),
+        )
+        .unwrap();
         assert_eq!(result, input);
     }
 
     #[test]
     fn strip_prefix_with_whitespace_around_colon() {
-        let input = r#"{"name" : "mcp_Tool"}"#;
-        let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
+        let tool_name_mapper = ToolNameMapper::new(8, 16);
+        let obfuscated = tool_name_mapper.obfuscate("tool");
+        let input = format!(r#"{{"name" : "{obfuscated}"}}"#);
+        let result =
+            String::from_utf8(strip_tool_prefix(input.as_bytes(), &tool_name_mapper).to_vec())
+                .unwrap();
         assert_eq!(result, r#"{"name": "tool"}"#);
     }
 
     #[test]
     fn does_not_strip_non_name_fields() {
-        let input = r#"{"id": "mcp_123", "name": "mcp_Tool"}"#;
-        let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
+        let tool_name_mapper = ToolNameMapper::new(8, 16);
+        let obfuscated = tool_name_mapper.obfuscate("tool");
+        let input = format!(r#"{{"id": "mcp_123", "name": "{obfuscated}"}}"#);
+        let result =
+            String::from_utf8(strip_tool_prefix(input.as_bytes(), &tool_name_mapper).to_vec())
+                .unwrap();
         assert_eq!(result, r#"{"id": "mcp_123", "name": "tool"}"#);
     }
 
     #[test]
-    fn strip_prefix_restores_snake_case_after_pascal_case_prefix() {
-        let input = r#"{"name": "mcp_Background_output"}"#;
-        let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
+    fn strip_prefix_restores_snake_case_after_obfuscation() {
+        let tool_name_mapper = ToolNameMapper::new(8, 16);
+        let obfuscated = tool_name_mapper.obfuscate("background_output");
+        let input = format!(r#"{{"name": "{obfuscated}"}}"#);
+        let result =
+            String::from_utf8(strip_tool_prefix(input.as_bytes(), &tool_name_mapper).to_vec())
+                .unwrap();
         assert_eq!(result, r#"{"name": "background_output"}"#);
     }
 

--- a/claude-auth-transform/src/response.rs
+++ b/claude-auth-transform/src/response.rs
@@ -12,6 +12,13 @@ use tracing::{debug, trace};
 static TOOL_PREFIX_RE: std::sync::LazyLock<Regex> =
     std::sync::LazyLock::new(|| Regex::new(r#""name"\s*:\s*"mcp_([^"]+)""#).unwrap());
 
+fn unprefix_tool_name(name: &str) -> String {
+    let Some((first, rest)) = name.split_at_checked(1) else {
+        return String::new();
+    };
+    format!("{}{rest}", first.to_ascii_lowercase())
+}
+
 pub fn transform_response<B>(response: Response<B>) -> Response<ClaudeBody<B>>
 where
     B: Body,
@@ -25,7 +32,9 @@ where
 /// Strips `"name": "mcp_<tool>"` -> `"name": "<tool>"` from a byte slice.
 fn strip_tool_prefix(input: &[u8]) -> Bytes {
     let text = String::from_utf8_lossy(input);
-    let result = TOOL_PREFIX_RE.replace_all(&text, r#""name": "$1""#);
+    let result = TOOL_PREFIX_RE.replace_all(&text, |caps: &regex::Captures<'_>| {
+        format!(r#""name": "{}""#, unprefix_tool_name(&caps[1]))
+    });
     Bytes::from(result.into_owned())
 }
 
@@ -123,14 +132,14 @@ mod tests {
 
     #[test]
     fn strip_prefix_from_name_field() {
-        let input = r#"{"name": "mcp_search", "id": "123"}"#;
+        let input = r#"{"name": "mcp_Search", "id": "123"}"#;
         let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
         assert_eq!(result, r#"{"name": "search", "id": "123"}"#);
     }
 
     #[test]
     fn strip_prefix_multiple_occurrences() {
-        let input = r#"{"name": "mcp_foo"} {"name": "mcp_bar"}"#;
+        let input = r#"{"name": "mcp_Foo"} {"name": "mcp_Bar"}"#;
         let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
         assert_eq!(result, r#"{"name": "foo"} {"name": "bar"}"#);
     }
@@ -144,16 +153,23 @@ mod tests {
 
     #[test]
     fn strip_prefix_with_whitespace_around_colon() {
-        let input = r#"{"name" : "mcp_tool"}"#;
+        let input = r#"{"name" : "mcp_Tool"}"#;
         let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
         assert_eq!(result, r#"{"name": "tool"}"#);
     }
 
     #[test]
     fn does_not_strip_non_name_fields() {
-        let input = r#"{"id": "mcp_123", "name": "mcp_tool"}"#;
+        let input = r#"{"id": "mcp_123", "name": "mcp_Tool"}"#;
         let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
         assert_eq!(result, r#"{"id": "mcp_123", "name": "tool"}"#);
+    }
+
+    #[test]
+    fn strip_prefix_restores_snake_case_after_pascal_case_prefix() {
+        let input = r#"{"name": "mcp_Background_output"}"#;
+        let result = String::from_utf8(strip_tool_prefix(input.as_bytes()).to_vec()).unwrap();
+        assert_eq!(result, r#"{"name": "background_output"}"#);
     }
 
     #[test]

--- a/claude-auth-transform/src/tool_names.rs
+++ b/claude-auth-transform/src/tool_names.rs
@@ -1,0 +1,138 @@
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use bimap::BiHashMap;
+use sha2::{Digest, Sha256};
+
+const TOOL_NAME_PREFIX: &str = "t_";
+
+#[derive(Debug)]
+pub struct ToolNameMapper {
+    min_hash_len: usize,
+    max_hash_len: usize,
+    mappings: RwLock<BiHashMap<String, String>>,
+}
+
+impl ToolNameMapper {
+    pub fn new(min_hash_len: usize, max_hash_len: usize) -> Self {
+        Self {
+            min_hash_len,
+            max_hash_len,
+            mappings: RwLock::new(BiHashMap::new()),
+        }
+    }
+
+    pub const fn min_hash_len(&self) -> usize {
+        self.min_hash_len
+    }
+
+    pub const fn max_hash_len(&self) -> usize {
+        self.max_hash_len
+    }
+
+    pub fn obfuscate(&self, original: &str) -> String {
+        if let Some(existing) = self.mappings_read().get_by_right(original) {
+            return existing.clone();
+        }
+
+        let mut mappings = self.mappings_write();
+
+        if let Some(existing) = mappings.get_by_right(original) {
+            return existing.clone();
+        }
+
+        for salt in 0_u32.. {
+            let hex = hashed_name(original, salt);
+            let max_len = self.max_hash_len.min(hex.len());
+            for len in self.min_hash_len..=max_len {
+                let candidate = format!("{TOOL_NAME_PREFIX}{}", &hex[..len]);
+                if !matches!(mappings.get_by_left(&candidate), Some(existing) if existing != original)
+                {
+                    mappings.insert(candidate.clone(), original.to_owned());
+                    return candidate;
+                }
+            }
+        }
+
+        unreachable!("collision search should always find a free tool name")
+    }
+
+    pub fn deobfuscate(&self, obfuscated: &str) -> String {
+        self.mappings_read()
+            .get_by_left(obfuscated)
+            .cloned()
+            .unwrap_or_else(|| obfuscated.to_owned())
+    }
+
+    fn mappings_read(&self) -> RwLockReadGuard<'_, BiHashMap<String, String>> {
+        self.mappings
+            .read()
+            .expect("tool-name mapper read lock poisoned")
+    }
+
+    fn mappings_write(&self) -> RwLockWriteGuard<'_, BiHashMap<String, String>> {
+        self.mappings
+            .write()
+            .expect("tool-name mapper write lock poisoned")
+    }
+}
+
+fn hashed_name(original: &str, salt: u32) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(original.as_bytes());
+    hasher.update([0]);
+    hasher.update(salt.to_be_bytes());
+    hex::encode(hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn obfuscate_round_trips_to_original_name() {
+        let mapper = ToolNameMapper::new(8, 64);
+
+        let obfuscated = mapper.obfuscate("background_output");
+
+        assert!(obfuscated.starts_with("t_"));
+        assert_eq!(mapper.deobfuscate(&obfuscated), "background_output");
+    }
+
+    #[test]
+    fn obfuscate_reuses_existing_mapping_for_same_name() {
+        let mapper = ToolNameMapper::new(8, 64);
+
+        let first = mapper.obfuscate("todowrite");
+        let second = mapper.obfuscate("todowrite");
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn obfuscate_expands_hash_length_to_avoid_collisions() {
+        let mapper = ToolNameMapper::new(1, 64);
+        let original = "background_output";
+        let hex = hashed_name(original, 0);
+        let colliding_candidate = format!("{TOOL_NAME_PREFIX}{}", &hex[..1]);
+
+        mapper
+            .mappings_write()
+            .insert(colliding_candidate.clone(), "other_tool".to_owned());
+
+        let obfuscated = mapper.obfuscate(original);
+
+        assert_ne!(obfuscated, colliding_candidate);
+        assert!(obfuscated.starts_with("t_"));
+        assert!(obfuscated.len() > colliding_candidate.len());
+        assert_eq!(mapper.deobfuscate(&obfuscated), original);
+    }
+
+    #[test]
+    fn obfuscate_respects_max_hash_len() {
+        let mapper = ToolNameMapper::new(4, 4);
+
+        let obfuscated = mapper.obfuscate("background_output");
+
+        assert_eq!(obfuscated.len(), TOOL_NAME_PREFIX.len() + 4);
+    }
+}

--- a/claude-auth-transform/src/transforms.rs
+++ b/claude-auth-transform/src/transforms.rs
@@ -7,20 +7,17 @@ use crate::{
     bodies::{Message, MessageBody, MessageContent, SystemEntry},
     config::CONFIG,
     signing::build_billing_header_value,
+    tool_names::ToolNameMapper,
 };
 
 const SYSTEM_IDENTITY: &str = "You are Claude Code, Anthropic's official CLI for Claude.";
-const TOOL_PREFIX: &str = "mcp_";
 const BILLING_PREFIX: &str = "x-anthropic-billing-header";
 
-fn prefix_tool_name(name: &str) -> String {
-    let Some((first, rest)) = name.split_at_checked(1) else {
-        return TOOL_PREFIX.to_owned();
-    };
-    format!("{TOOL_PREFIX}{}{rest}", first.to_ascii_uppercase())
-}
-
-pub fn transform_body(bytes: &[u8], config: &TransformConfig) -> Result<Vec<u8>, Error> {
+pub fn transform_body(
+    bytes: &[u8],
+    config: &TransformConfig,
+    tool_name_mapper: &ToolNameMapper,
+) -> Result<Vec<u8>, Error> {
     let Ok(mut parsed): Result<MessageBody, _> = serde_json::from_slice(bytes) else {
         debug!("Failed to parse body, skipping transformation");
         return Ok(bytes.to_vec());
@@ -46,18 +43,17 @@ pub fn transform_body(bytes: &[u8], config: &TransformConfig) -> Result<Vec<u8>,
         parsed.thinking.remove("effort");
     }
 
-    // Anthropic validates Claude Code tool names as PascalCase after the
-    // reserved mcp_ prefix (for example mcp_Bash instead of mcp_bash).
+    // Obfuscate all tool names to avoid name-based upstream validation.
     parsed.tools.iter_mut().for_each(|tool| {
         if let Some(name) = tool.name.as_mut() {
-            *name = prefix_tool_name(name);
+            *name = tool_name_mapper.obfuscate(name);
         }
     });
 
     if let Some(tool_choice) = parsed.tool_choice.as_mut()
         && let Some(name) = tool_choice.name.as_mut()
     {
-        *name = prefix_tool_name(name);
+        *name = tool_name_mapper.obfuscate(name);
     }
 
     for message in &mut parsed.messages {
@@ -68,9 +64,9 @@ pub fn transform_body(bytes: &[u8], config: &TransformConfig) -> Result<Vec<u8>,
                     && let Some(name) = block.extra.get_mut("name")
                     && name.is_string()
                 {
-                    *name =
-                        prefix_tool_name(name.as_str().expect("name already checked as string"))
-                            .into();
+                    *name = tool_name_mapper
+                        .obfuscate(name.as_str().expect("name already checked as string"))
+                        .into();
                 }
             }
         }
@@ -321,12 +317,14 @@ mod tests {
     fn run_transform(input: Value) -> Value {
         let bytes = serde_json::to_vec(&input).unwrap();
         let config = TransformConfig::default();
-        let output = transform_body(&bytes, &config).unwrap();
+        let tool_name_mapper =
+            ToolNameMapper::new(config.tool_name_hash_len, config.tool_name_max_hash_len);
+        let output = transform_body(&bytes, &config, &tool_name_mapper).unwrap();
         serde_json::from_slice(&output).unwrap()
     }
 
     #[test]
-    fn transform_body_moves_non_core_system_text_and_pascal_cases_tool_names() {
+    fn transform_body_moves_non_core_system_text_and_obfuscates_tool_names() {
         let input = json!({
             "system": [{ "type": "text", "text": "OpenCode and opencode" }],
             "tools": [{ "name": "search" }],
@@ -350,8 +348,14 @@ mod tests {
             parsed["messages"][0]["content"][0]["text"],
             "OpenCode and opencode"
         );
-        assert_eq!(parsed["tools"][0]["name"], "mcp_Search");
-        assert_eq!(parsed["messages"][0]["content"][1]["name"], "mcp_Lookup");
+        assert!(parsed["tools"][0]["name"]
+            .as_str()
+            .unwrap()
+            .starts_with("t_"));
+        assert!(parsed["messages"][0]["content"][1]["name"]
+            .as_str()
+            .unwrap()
+            .starts_with("t_"));
     }
 
     #[test]
@@ -669,7 +673,10 @@ mod tests {
         let parsed = run_transform(input);
 
         assert_eq!(parsed["tool_choice"]["type"], "tool");
-        assert_eq!(parsed["tool_choice"]["name"], "mcp_Get_weather");
+        assert!(parsed["tool_choice"]["name"]
+            .as_str()
+            .unwrap()
+            .starts_with("t_"));
     }
 
     #[test]
@@ -734,10 +741,10 @@ mod tests {
 
         let parsed = run_transform(input);
 
-        assert_eq!(parsed["tools"][0]["name"], "mcp_Search");
-        assert_eq!(parsed["tools"][1]["name"], "mcp_Analyze");
+        assert!(parsed["tools"][0]["name"].as_str().unwrap().starts_with("t_"));
+        assert!(parsed["tools"][1]["name"].as_str().unwrap().starts_with("t_"));
         assert_eq!(parsed["tool_choice"]["type"], "tool");
-        assert_eq!(parsed["tool_choice"]["name"], "mcp_Analyze");
+        assert_eq!(parsed["tool_choice"]["name"], parsed["tools"][1]["name"]);
     }
 
     #[test]
@@ -755,7 +762,7 @@ mod tests {
         let parsed = run_transform(input);
 
         assert_eq!(parsed["tool_choice"]["type"], "tool");
-        assert_eq!(parsed["tool_choice"]["name"], "mcp_Analyze");
+        assert_eq!(parsed["tool_choice"]["name"], parsed["tools"][0]["name"]);
         assert_eq!(parsed["tool_choice"]["disable_parallel_tool_use"], true);
     }
 }

--- a/claude-auth-transform/src/transforms.rs
+++ b/claude-auth-transform/src/transforms.rs
@@ -13,6 +13,13 @@ const SYSTEM_IDENTITY: &str = "You are Claude Code, Anthropic's official CLI for
 const TOOL_PREFIX: &str = "mcp_";
 const BILLING_PREFIX: &str = "x-anthropic-billing-header";
 
+fn prefix_tool_name(name: &str) -> String {
+    let Some((first, rest)) = name.split_at_checked(1) else {
+        return TOOL_PREFIX.to_owned();
+    };
+    format!("{TOOL_PREFIX}{}{rest}", first.to_ascii_uppercase())
+}
+
 pub fn transform_body(bytes: &[u8], config: &TransformConfig) -> Result<Vec<u8>, Error> {
     let Ok(mut parsed): Result<MessageBody, _> = serde_json::from_slice(bytes) else {
         debug!("Failed to parse body, skipping transformation");
@@ -39,17 +46,18 @@ pub fn transform_body(bytes: &[u8], config: &TransformConfig) -> Result<Vec<u8>,
         parsed.thinking.remove("effort");
     }
 
-    // Prefix all tool names with a reserved prefix
+    // Anthropic validates Claude Code tool names as PascalCase after the
+    // reserved mcp_ prefix (for example mcp_Bash instead of mcp_bash).
     parsed.tools.iter_mut().for_each(|tool| {
         if let Some(name) = tool.name.as_mut() {
-            name.insert_str(0, TOOL_PREFIX);
+            *name = prefix_tool_name(name);
         }
     });
 
     if let Some(tool_choice) = parsed.tool_choice.as_mut()
         && let Some(name) = tool_choice.name.as_mut()
     {
-        name.insert_str(0, TOOL_PREFIX);
+        *name = prefix_tool_name(name);
     }
 
     for message in &mut parsed.messages {
@@ -60,12 +68,9 @@ pub fn transform_body(bytes: &[u8], config: &TransformConfig) -> Result<Vec<u8>,
                     && let Some(name) = block.extra.get_mut("name")
                     && name.is_string()
                 {
-                    *name = format!(
-                        "{}{}",
-                        TOOL_PREFIX,
-                        name.as_str().expect("name already checked as string")
-                    )
-                    .into();
+                    *name =
+                        prefix_tool_name(name.as_str().expect("name already checked as string"))
+                            .into();
                 }
             }
         }
@@ -321,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn transform_body_moves_non_core_system_text_and_prefixes_tool_names() {
+    fn transform_body_moves_non_core_system_text_and_pascal_cases_tool_names() {
         let input = json!({
             "system": [{ "type": "text", "text": "OpenCode and opencode" }],
             "tools": [{ "name": "search" }],
@@ -345,8 +350,8 @@ mod tests {
             parsed["messages"][0]["content"][0]["text"],
             "OpenCode and opencode"
         );
-        assert_eq!(parsed["tools"][0]["name"], "mcp_search");
-        assert_eq!(parsed["messages"][0]["content"][1]["name"], "mcp_lookup");
+        assert_eq!(parsed["tools"][0]["name"], "mcp_Search");
+        assert_eq!(parsed["messages"][0]["content"][1]["name"], "mcp_Lookup");
     }
 
     #[test]
@@ -664,7 +669,7 @@ mod tests {
         let parsed = run_transform(input);
 
         assert_eq!(parsed["tool_choice"]["type"], "tool");
-        assert_eq!(parsed["tool_choice"]["name"], "mcp_get_weather");
+        assert_eq!(parsed["tool_choice"]["name"], "mcp_Get_weather");
     }
 
     #[test]
@@ -729,10 +734,10 @@ mod tests {
 
         let parsed = run_transform(input);
 
-        assert_eq!(parsed["tools"][0]["name"], "mcp_search");
-        assert_eq!(parsed["tools"][1]["name"], "mcp_analyze");
+        assert_eq!(parsed["tools"][0]["name"], "mcp_Search");
+        assert_eq!(parsed["tools"][1]["name"], "mcp_Analyze");
         assert_eq!(parsed["tool_choice"]["type"], "tool");
-        assert_eq!(parsed["tool_choice"]["name"], "mcp_analyze");
+        assert_eq!(parsed["tool_choice"]["name"], "mcp_Analyze");
     }
 
     #[test]
@@ -750,7 +755,7 @@ mod tests {
         let parsed = run_transform(input);
 
         assert_eq!(parsed["tool_choice"]["type"], "tool");
-        assert_eq!(parsed["tool_choice"]["name"], "mcp_analyze");
+        assert_eq!(parsed["tool_choice"]["name"], "mcp_Analyze");
         assert_eq!(parsed["tool_choice"]["disable_parallel_tool_use"], true);
     }
 }

--- a/claude-auth-transform/src/transforms.rs
+++ b/claude-auth-transform/src/transforms.rs
@@ -348,14 +348,18 @@ mod tests {
             parsed["messages"][0]["content"][0]["text"],
             "OpenCode and opencode"
         );
-        assert!(parsed["tools"][0]["name"]
-            .as_str()
-            .unwrap()
-            .starts_with("t_"));
-        assert!(parsed["messages"][0]["content"][1]["name"]
-            .as_str()
-            .unwrap()
-            .starts_with("t_"));
+        assert!(
+            parsed["tools"][0]["name"]
+                .as_str()
+                .unwrap()
+                .starts_with("t_")
+        );
+        assert!(
+            parsed["messages"][0]["content"][1]["name"]
+                .as_str()
+                .unwrap()
+                .starts_with("t_")
+        );
     }
 
     #[test]
@@ -673,10 +677,12 @@ mod tests {
         let parsed = run_transform(input);
 
         assert_eq!(parsed["tool_choice"]["type"], "tool");
-        assert!(parsed["tool_choice"]["name"]
-            .as_str()
-            .unwrap()
-            .starts_with("t_"));
+        assert!(
+            parsed["tool_choice"]["name"]
+                .as_str()
+                .unwrap()
+                .starts_with("t_")
+        );
     }
 
     #[test]
@@ -741,8 +747,18 @@ mod tests {
 
         let parsed = run_transform(input);
 
-        assert!(parsed["tools"][0]["name"].as_str().unwrap().starts_with("t_"));
-        assert!(parsed["tools"][1]["name"].as_str().unwrap().starts_with("t_"));
+        assert!(
+            parsed["tools"][0]["name"]
+                .as_str()
+                .unwrap()
+                .starts_with("t_")
+        );
+        assert!(
+            parsed["tools"][1]["name"]
+                .as_str()
+                .unwrap()
+                .starts_with("t_")
+        );
         assert_eq!(parsed["tool_choice"]["type"], "tool");
         assert_eq!(parsed["tool_choice"]["name"], parsed["tools"][1]["name"]);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,6 +104,24 @@ pub struct TransformArgs {
         value_parser = parse_beta_flags,
     )]
     pub beta_flags_override: Option<Vec<String>>,
+
+    /// Minimum number of hex characters to use for obfuscated tool names.
+    #[arg(
+        long = "tool-name-hash-len",
+        env = "CLAUDE_PROXY_TOOL_NAME_HASH_LEN",
+        value_parser = parse_tool_name_hash_len,
+        default_value_t = 8,
+    )]
+    pub tool_name_hash_len: usize,
+
+    /// Maximum number of hex characters to use for obfuscated tool names.
+    #[arg(
+        long = "tool-name-max-hash-len",
+        env = "CLAUDE_PROXY_TOOL_NAME_MAX_HASH_LEN",
+        value_parser = parse_tool_name_hash_len,
+        default_value_t = 16,
+    )]
+    pub tool_name_max_hash_len: usize,
 }
 
 impl TransformArgs {
@@ -115,6 +133,8 @@ impl TransformArgs {
             entrypoint: self.entrypoint,
             user_agent_override: self.user_agent_override,
             base_betas: self.beta_flags_override.unwrap_or(default.base_betas),
+            tool_name_hash_len: self.tool_name_hash_len,
+            tool_name_max_hash_len: self.tool_name_max_hash_len,
             ..default
         }
     }
@@ -142,4 +162,18 @@ fn parse_bool_flag(s: &str) -> Result<bool, String> {
         "0" | "false" | "FALSE" | "False" | "no" | "NO" => Ok(false),
         other => Err(format!("invalid boolean value: {other}")),
     }
+}
+
+fn parse_tool_name_hash_len(s: &str) -> Result<usize, String> {
+    let value = s
+        .parse::<usize>()
+        .map_err(|e| format!("invalid tool-name-hash-len '{s}': {e}"))?;
+
+    if !(1..=64).contains(&value) {
+        return Err(format!(
+            "invalid tool-name-hash-len '{s}': expected a value between 1 and 64"
+        ));
+    }
+
+    Ok(value)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,8 @@ async fn run(config: ServerConfig) -> anyhow::Result<()> {
         entrypoint = %transform_config.entrypoint,
         user_agent_override = ?transform_config.user_agent_override,
         base_betas = ?transform_config.base_betas,
+        tool_name_hash_len = transform_config.tool_name_hash_len,
+        tool_name_max_hash_len = transform_config.tool_name_max_hash_len,
         "Transform configuration"
     );
     tracing::debug!(
@@ -230,7 +232,7 @@ async fn messages_handler(
     *response.headers_mut() = headers;
 
     // Wrap through ClaudeBody to strip tool prefixes from SSE events
-    Ok(transform_response(response).map(Body::new))
+    Ok(transform_response(response, state.transform.tool_name_mapper()).map(Body::new))
 }
 
 /// When upstream returns 401 Unauthorized, attempt a forced credential


### PR DESCRIPTION
## Summary
- obfuscate outbound tool names in the transform layer using an in-memory bidirectional map
- make the hash length configurable with min/max bounds and collision-safe expansion
- deobfuscate response payloads back to original tool names while preserving existing proxy behavior

## Verification
- cargo test -p claude-auth-transform
- cargo test --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- hurl --test tests/hurl/*.hurl